### PR TITLE
Merge from dev

### DIFF
--- a/OpenGL.xcodeproj/project.pbxproj
+++ b/OpenGL.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		581C1E981E67619600738B0E /* VecMat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 581C1E971E67619600738B0E /* VecMat.cpp */; };
 		582FB5B51E32621600C031C6 /* Matrices.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 582FB5B31E32621600C031C6 /* Matrices.cpp */; };
 		582FB5BB1E3567FD00C031C6 /* cup.obj in CopyFiles */ = {isa = PBXBuildFile; fileRef = 582FB5B91E3567EE00C031C6 /* cup.obj */; };
 		582FB5BE1E35E46100C031C6 /* ObjectLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 582FB5BC1E35E46100C031C6 /* ObjectLoader.cpp */; };
@@ -81,6 +82,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		581C1E951E675D7700738B0E /* VecMat.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = VecMat.hpp; sourceTree = "<group>"; };
+		581C1E971E67619600738B0E /* VecMat.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VecMat.cpp; sourceTree = "<group>"; };
 		582FB5B31E32621600C031C6 /* Matrices.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Matrices.cpp; sourceTree = "<group>"; };
 		582FB5B41E32621600C031C6 /* Matrices.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Matrices.hpp; sourceTree = "<group>"; };
 		582FB5B61E32627F00C031C6 /* Enumerations.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Enumerations.h; sourceTree = "<group>"; };
@@ -226,6 +229,8 @@
 				58C8F1B71E4F242B00A7851F /* Quaternion.hpp */,
 				587AE8361E60A4FE00881681 /* Camera.cpp */,
 				587AE8371E60A4FE00881681 /* Camera.hpp */,
+				581C1E951E675D7700738B0E /* VecMat.hpp */,
+				581C1E971E67619600738B0E /* VecMat.cpp */,
 			);
 			path = OpenGL;
 			sourceTree = "<group>";
@@ -321,6 +326,7 @@
 				58C8F1B81E4F242B00A7851F /* Quaternion.cpp in Sources */,
 				58B8F0A11E1CE92B005C5C5F /* Shapes.cpp in Sources */,
 				5869ACBD1E29033A00182916 /* CubeTransformDemo.cpp in Sources */,
+				581C1E981E67619600738B0E /* VecMat.cpp in Sources */,
 				58B8F0BC1E1FA61F005C5C5F /* Logger.cpp in Sources */,
 				587AE8381E60A4FE00881681 /* Camera.cpp in Sources */,
 				58B8F0A71E1CEF0F005C5C5F /* Detect.cpp in Sources */,

--- a/OpenGL/Camera.cpp
+++ b/OpenGL/Camera.cpp
@@ -18,126 +18,69 @@ Camera::Camera() {}
 
 Camera& Camera::getInstance() {
     static Camera instance;
-    
-    instance.fwd_mat4 = Matrix<float>({
-        Row<float>({0.0f, 0.0f, -1.0f, 0.0f})
-    });
-    
-    instance.rgt_mat4 = Matrix<float>({
-        Row<float>({1.0f, 0.0f, 0.0f, 0.0f})
-    });
-    
-    instance.up_mat4 = Matrix<float>({
-        Row<float>({0.0f, 1.0f, 0.0f, 0.0f})
-    });
-    
-    instance.rotation_mat4 = instance.m.getMatrixOfType(ZERO_MAT4);
-    
     return instance;
 }
 
-void Camera::_pitch(CameraRotation rotation) {
-    switch(rotation) {
-        case ROT_UP: {
-            cam_pitch += cam_pitch_speed;
+void Camera::_pitch(CameraOrientation orientation) {
+    switch(orientation) {
+        case PITCH_UP: {
             break;
         }
-        case ROT_DOWN: {
-            cam_pitch -= cam_pitch_speed;
+        case PITCH_DOWN: {
             break;
         }
     }
-    
-    _updateViewQuaternionOnAxis(AXIS_X);
 }
 
-void Camera::_yaw(CameraRotation rotation) {
-    switch(rotation) {
-        case ROT_RIGHT: {
-            cam_yaw += cam_yaw_speed;
+void Camera::_yaw(CameraOrientation orientation) {
+    switch(orientation) {
+        case YAW_LEFT: {
             break;
         }
-        case ROT_LEFT: {
-            cam_yaw -= cam_yaw_speed;
+        case YAW_RIGHT: {
             break;
         }
     }
-    
-    _updateViewQuaternionOnAxis(AXIS_Y);
 }
 
-void Camera::_roll(CameraRotation rotation) {
-    switch(rotation) {
-        case ROT_LEFT: {
-            cam_roll += cam_roll_speed;
+void Camera::_roll(CameraOrientation orientation) {
+    switch(orientation) {
+        case ROLL_LEFT: {
             break;
         }
-        case ROT_RIGHT: {
-            cam_roll -= cam_roll_speed;
+        case ROLL_RIGHT: {
             break;
         }
     }
-    
-    _updateViewQuaternionOnAxis(AXIS_Z);
 }
 
 void Camera::_move(CameraMovement movement) {
     switch(movement) {
         case MOVE_FORWARD: {
-            cam_pos_z -= cam_move_speed;
             break;
         }
         case MOVE_BACKWARD: {
-            cam_pos_z += cam_move_speed;
             break;
         }
         case MOVE_LEFT: {
-            cam_pos_x -= cam_move_speed;
             break;
         }
         case MOVE_RIGHT: {
-            cam_pos_x += cam_move_speed;
             break;
         }
         case MOVE_UP: {
-            cam_pos_y -= cam_move_speed;
             break;
         }
         case MOVE_DOWN: {
-            cam_pos_y += cam_move_speed;
             break;
         }
     }
-    
-    _updateTranslation();
-}
-
-void Camera::_pitchTo(float deg) {
-    cam_pitch = deg;
-}
-
-void Camera::_yawTo(float deg) {
-    cam_yaw = deg;
-}
-
-void Camera::_rollTo(float deg) {
-    cam_roll = deg;
-}
-
-void Camera::_moveTo(float _x, float _y, float _z) {
-    cam_pos_x = _x;
-    cam_pos_y = _y;
-    cam_pos_z = _z;
 }
 
 string Camera::_repr() {
     stringstream oss;
-    
     oss << "Camera program: " << program << endl;
-    oss << "Camera pitch: " << cam_pitch << ", yaw: " << cam_yaw << ", roll: " << cam_roll << endl;
-    oss << "Camera position x: " << cam_pos_x << ", y: " << cam_pos_y << ", z: " << cam_pos_z << endl;
     oss << "Camera fov: " << fov << endl;
-    
     return oss.str();
 }
 
@@ -145,27 +88,34 @@ void Camera::_applyProgram(GLuint _program) {
     program = _program;
 }
 
-void Camera::_reset(void) {
+void Camera::_create(void) {
     
-    cam_pos_x = 0.0f;
-    cam_pos_y = 0.0f;
-    cam_pos_z = 15.0f;
+    m.translateTo(TRANSLATE_X, 0.0f);
+    m.translateTo(TRANSLATE_Y, 0.0f);
+    m.translateTo(TRANSLATE_Z, -15.0f);
     
-    cam_pitch = 0.0f;
-    cam_yaw = 0.0f;
-    cam_roll = 0.0f;
-    
-    cam_heading = 0.0f;
-    
-    _updateTranslation();
-    _applyProjection("projection");
-    
-    Quaternion::create_versor(quaternion_mat4, -cam_heading, 0.0f, 1.0f, 0.0f);
-    Quaternion::quat_to_mat4(rotation_mat4, quaternion_mat4);
-    
+    rotation_mat4 = m.getMatrixOfType(ZERO_MAT4);
     Matrix<float> translation_mat4 = m.getMatrixOfType(TRANSLATION);
+    
+    Quaternion::create_versor(quaternion, -cam_heading, 0.0f, 0.0f, 0.0f);
+    Quaternion::quat_to_mat4(rotation_mat4, quaternion);
+    
     Matrix<float> view_mat4 = translation_mat4 * rotation_mat4;
     vector<float> view_mat4_unwound = view_mat4.unwind();
+    
+    fwd = Matrix<float>({
+        Row<float>({0.0f, 0.0f, -1.0f, 0.0f})
+    });
+    
+    rgt = Matrix<float>({
+        Row<float>({1.0f, 0.0f, 0.0f, 0.0f})
+    });
+    
+    up = Matrix<float>({
+        Row<float>({0.0f, 1.0f, 0.0f, 0.0f})
+    });
+    
+    _applyProjection("projection");
     
     GLuint view_loc = glGetUniformLocation(program, "view");
     if(GL_TRUE != view_loc) {
@@ -174,70 +124,11 @@ void Camera::_reset(void) {
     else {
         cout << "Camera reset was unable to apply the view quaternion matrix." << endl;
     }
-    
-    cout << "Camera reset:" << _repr() << endl;
-    cout << "T mat4: " << translation_mat4.repr() << endl;
-    cout << "R mat4: " << rotation_mat4.repr() << endl;
-    cout << "Q mat4: " << quaternion_mat4.repr() << endl;
-    
-    cout << "FW mat4: " << fwd_mat4.repr() << endl;
-    cout << "RT mat4: " << rgt_mat4.repr() << endl;
-    cout << "UP mat4: " << up_mat4.repr() << endl;
-}
-
-void Camera::_updateTranslation(void) {
-    m.translateTo(TRANSLATE_X, -cam_pos_x);
-    m.translateTo(TRANSLATE_Y, -cam_pos_y);
-    m.translateTo(TRANSLATE_Z, -cam_pos_z);
 }
 
 void Camera::_updateViewportSize(const int _gl_viewport_w, const int _gl_viewport_h) {
     gl_viewport_w = _gl_viewport_w;
     gl_viewport_h = _gl_viewport_h;
-}
-
-void Camera::_updateViewQuaternionOnAxis(RotationAxis axis) {
-    
-    _updateTranslation();
-    
-    Matrix<float> local_q_mat4;
-
-    switch(axis) {
-        case AXIS_X: {
-            Quaternion::create_versor(local_q_mat4, cam_pitch, rgt_mat4.getValueAtIndex(0), rgt_mat4.getValueAtIndex(1), rgt_mat4.getValueAtIndex(2));
-            break;
-        }
-        case AXIS_Y: {
-            Quaternion::create_versor(local_q_mat4, cam_yaw, up_mat4.getValueAtIndex(0), up_mat4.getValueAtIndex(1), up_mat4.getValueAtIndex(2));
-            break;
-        }
-        case AXIS_Z: {
-            Quaternion::create_versor(local_q_mat4, cam_roll, fwd_mat4.getValueAtIndex(0), fwd_mat4.getValueAtIndex(1), fwd_mat4.getValueAtIndex(2));
-            break;
-        }
-    }
-    
-    Quaternion::mult_quat_quat(quaternion_mat4, local_q_mat4, quaternion_mat4);
-    Quaternion::quat_to_mat4(rotation_mat4, quaternion_mat4);
-    
-    Matrix<float> translation_mat4 = m.getMatrixOfType(TRANSLATION);
-    Matrix<float> view_mat4 = translation_mat4.inverse() * rotation_mat4.inverse();
-    vector<float> view_mat4_unwound = view_mat4.unwind();
-    
-    fwd_mat4 *= rotation_mat4;
-    rgt_mat4 *= rotation_mat4;
-    up_mat4 *= rotation_mat4;
-    
-    GLuint view_loc = glGetUniformLocation(program, "view");
-    if(GL_TRUE != view_loc) {
-        glUniformMatrix4fv(view_loc, 1, GL_FALSE, &view_mat4_unwound[0]);
-    }
-    else {
-        cout << "Camera was unable to apply the view quaternion matrix." << endl;
-    }
-}
-
-void Camera::_applyView(void) {
 }
 
 Matrix<float> Camera::_calculateProjectionMatrix(void) {

--- a/OpenGL/Camera.cpp
+++ b/OpenGL/Camera.cpp
@@ -68,7 +68,7 @@ void Camera::_mult_quat_quat(float *result, float *r, float *s) {
     result[0] = s[0] * r[0] - s[1] * r[1] - s[2] * r[2] - s[3] * r[3];
     result[1] = s[0] * r[1] + s[1] * r[0] - s[2] * r[3] + s[3] * r[2];
     result[2] = s[0] * r[2] + s[1] * r[3] + s[2] * r[0] - s[3] * r[1];
-    result[3] = s[0] * r[3] - s[1] * r[2] + s[2] * r[1] - s[3] * r[0];
+    result[3] = s[0] * r[3] - s[1] * r[2] + s[2] * r[1] + s[3] * r[0];
     _normalise_quat(result);
 }
 

--- a/OpenGL/Camera.cpp
+++ b/OpenGL/Camera.cpp
@@ -74,8 +74,7 @@ void Camera::_mult_quat_quat(float *result, float *r, float *s) {
 
 string Camera::_repr() {
     stringstream oss;
-    oss << "Camera program: " << program << endl;
-    oss << "Camera fov: " << fov << endl;
+    oss << "Camera fov: \t" << fov << endl;
     return oss.str();
 }
 
@@ -100,9 +99,7 @@ void Camera::_create(void) {
     /**
      *  Set up the projection matrix
      */
-    float near = 0.1f;
-    float far = 100.0f;
-    float aspect = (float)gl_viewport_w / (float)gl_viewport_h;
+    aspect = (float)gl_viewport_w / (float)gl_viewport_h;
     proj_mat = perspective(fov, aspect, near, far);
     
     /**
@@ -247,4 +244,19 @@ void Camera::_update(CameraKey key) {
     
     view_mat = inverse(R) * inverse(T);
     glUniformMatrix4fv(view_mat_location, 1, GL_FALSE, view_mat.m);
+}
+
+void Camera::_updateFov(float _d) {
+    
+    if(fov + _d <= 20.0f) {
+        return;
+    }
+    else if(fov + _d >= 100.0f) {
+        return;
+    }
+    
+    fov += _d;
+    proj_mat = perspective(fov, aspect, near, far);
+    proj_mat_location = glGetUniformLocation(program, "projection");
+    glUniformMatrix4fv(proj_mat_location, 1, GL_FALSE, proj_mat.m);
 }

--- a/OpenGL/Camera.hpp
+++ b/OpenGL/Camera.hpp
@@ -60,6 +60,9 @@ private:
     int gl_viewport_h;
     int gl_viewport_w;
     float fov = 67.0f;
+    float near = 0.1f;
+    float far = 100.0f;
+    float aspect;
     
     float cam_speed = 0.25f;
     float cam_heading_speed = 1.0f;
@@ -75,6 +78,7 @@ private:
     void _updateViewportSize(const int _gl_viewport_w, const int gl_viewport_h);
     void _create(void);
     void _update(CameraKey key);
+    void _updateFov(float _d);
 
     std::string _repr(void);
     
@@ -94,6 +98,10 @@ public:
     
     static void update(CameraKey key) {
         getInstance()._update(key);
+    }
+    
+    static void updateFov(float _d) {
+        getInstance()._updateFov(_d);
     }
     
     static std::string repr(void) {

--- a/OpenGL/Camera.hpp
+++ b/OpenGL/Camera.hpp
@@ -17,16 +17,13 @@
 #include <string>
 #include "VecMat.hpp"
 
-enum CameraMovement {
+enum CameraKey {
     MOVE_FORWARD,
     MOVE_BACKWARD,
     MOVE_LEFT,
     MOVE_RIGHT,
     MOVE_UP,
-    MOVE_DOWN
-};
-
-enum CameraOrientation {
+    MOVE_DOWN,
     PITCH_UP,
     PITCH_DOWN,
     YAW_LEFT,
@@ -65,22 +62,19 @@ private:
     float fov = 67.0f;
     
     float cam_speed = 0.25f;
-    float cam_heading_speed = 100.0f;
+    float cam_heading_speed = 1.0f;
     float cam_heading = 0.0f;
     
     void _create_versor(float *q, float a, float x, float y, float z);
     void _quat_to_mat4(float *m, float *q);
-    void _applyProgram(GLuint _progam);
-    void _updateTranslation(void);
+    void _mult_quat_quat(float *result, float *r, float *s);
+    void _normalise_quat(float *q);
     
-    void _pitch(CameraOrientation orientation);
-    void _yaw(CameraOrientation orientation);
-    void _roll(CameraOrientation orientation);
-    void _moved(CameraMovement movement);
+    void _applyProgram(GLuint _progam);
     
     void _updateViewportSize(const int _gl_viewport_w, const int gl_viewport_h);
     void _create(void);
-    void _move(vec3 movement);
+    void _update(CameraKey key);
 
     std::string _repr(void);
     
@@ -90,28 +84,16 @@ public:
         getInstance()._applyProgram(_program);
     }
     
-    static void pitch(CameraOrientation orientation) {
-        getInstance()._pitch(orientation);
-    }
-    
-    static void yaw(CameraOrientation orientation) {
-        getInstance()._yaw(orientation);
-    }
-    
-    static void roll(CameraOrientation orientation) {
-        getInstance()._roll(orientation);
-    }
-    
-    static void moved(CameraMovement movement) {
-        getInstance()._moved(movement);
-    }
-    
     static void updateViewportSize(const int _gl_viewport_w, const int _gl_viewport_h) {
         getInstance()._updateViewportSize(_gl_viewport_w, _gl_viewport_h);
     }
     
     static void create(void) {
         getInstance()._create();
+    }
+    
+    static void update(CameraKey key) {
+        getInstance()._update(key);
     }
     
     static std::string repr(void) {

--- a/OpenGL/Camera.hpp
+++ b/OpenGL/Camera.hpp
@@ -35,9 +35,11 @@ enum CameraRotation {
     ROT_RIGHT
 };
 
-enum RotationType {
-    QUATERNION,
-    EULER
+enum RotationAxis {
+    AXIS_X,
+    AXIS_Y,
+    AXIS_Z,
+    AXIS_ALL
 };
 
 class Camera {
@@ -51,7 +53,6 @@ private:
     
     GLuint program;
     Matrices m;
-    RotationType r_type = QUATERNION;
     
     float cam_pos_x = 0.0f;
     float cam_pos_y = 0.0f;
@@ -66,12 +67,17 @@ private:
     float cam_roll_speed = 2.0f;
     float cam_move_speed = 0.1f;
     
+    Matrix<float> fwd_mat4;
+    Matrix<float> rgt_mat4;
+    Matrix<float> up_mat4;
+    Matrix<float> rotation_mat4;
+    Matrix<float> quaternion_mat4;
+    
     float fov = 67.0f * one_deg_in_rad;
     
     void _applyProgram(GLuint _progam);
-    void _switchRotationType(RotationType _r_type);
-    void applyViewQuaternion(void);
-    void applyViewEuler(void);
+    void _updateTranslation(void);
+    void _applyViewQuaternionOnAxis(RotationAxis axis);
     
     void _pitch(CameraRotation rotation);
     void _yaw(CameraRotation rotation);
@@ -82,6 +88,8 @@ private:
     void _yawTo(float deg);
     void _rollTo(float deg);
     void _moveTo(float _x, float _y, float _z);
+    
+    void _reset(void);
     
     std::string _repr(void);
     
@@ -123,8 +131,8 @@ public:
         getInstance()._moveTo(_x, _y, _z);
     }
     
-    static void switcRotationType(RotationType _r_type) {
-        getInstance()._switchRotationType(_r_type);
+    static void reset(void) {
+        getInstance()._reset();
     }
     
     static std::string repr(void) {

--- a/OpenGL/Camera.hpp
+++ b/OpenGL/Camera.hpp
@@ -28,11 +28,13 @@ enum CameraMovement {
     MOVE_DOWN
 };
 
-enum CameraRotation {
-    ROT_UP,
-    ROT_DOWN,
-    ROT_LEFT,
-    ROT_RIGHT
+enum CameraOrientation {
+    PITCH_UP,
+    PITCH_DOWN,
+    YAW_LEFT,
+    YAW_RIGHT,
+    ROLL_LEFT,
+    ROLL_RIGHT
 };
 
 enum RotationAxis {
@@ -57,45 +59,32 @@ private:
     int gl_viewport_w;
     float fov = 67.0f * one_deg_in_rad;
     
-    float cam_pos_x = 0.0f;
-    float cam_pos_y = 0.0f;
-    float cam_pos_z = 5.0f;
-    
-    float cam_pitch = 0.0f;
-    float cam_yaw = 0.0f;
-    float cam_roll = 0.0f;
-    
-    float cam_pitch_speed = 0.1f;
-    float cam_yaw_speed = 0.1f;
-    float cam_roll_speed = 0.1f;
-    float cam_move_speed = 0.1f;
+    float cam_pitch_speed = 0.4f;
+    float cam_yaw_speed = 0.4f;
+    float cam_roll_speed = 0.4f;
+    float cam_move_speed = 0.4f;
     float cam_heading = 0.0f;
     
-    Matrix<float> fwd_mat4;
-    Matrix<float> rgt_mat4;
-    Matrix<float> up_mat4;
+    Matrix<float> fwd;
+    Matrix<float> rgt;
+    Matrix<float> up;
+    
     Matrix<float> rotation_mat4;
-    Matrix<float> quaternion_mat4;
+    Matrix<float> quaternion;
+    
     Matrix<float> _calculateProjectionMatrix(void);
     
     void _applyProgram(GLuint _progam);
     void _updateTranslation(void);
     void _updateViewportSize(const int _gl_viewport_w, const int gl_viewport_h);
     void _applyProjection(const char *uniform_location_name);
-    void _updateViewQuaternionOnAxis(RotationAxis axis);
-    void _applyView(void);
     
-    void _pitch(CameraRotation rotation);
-    void _yaw(CameraRotation rotation);
-    void _roll(CameraRotation rotation);
+    void _pitch(CameraOrientation orientation);
+    void _yaw(CameraOrientation orientation);
+    void _roll(CameraOrientation orientation);
     void _move(CameraMovement movement);
     
-    void _pitchTo(float deg);
-    void _yawTo(float deg);
-    void _rollTo(float deg);
-    void _moveTo(float _x, float _y, float _z);
-    
-    void _reset(void);
+    void _create(void);
     
     std::string _repr(void);
     
@@ -105,44 +94,28 @@ public:
         getInstance()._applyProgram(_program);
     }
     
-    static void pitch(CameraRotation rotation) {
-        getInstance()._pitch(rotation);
+    static void pitch(CameraOrientation orientation) {
+        getInstance()._pitch(orientation);
     }
     
-    static void yaw(CameraRotation rotation) {
-        getInstance()._yaw(rotation);
+    static void yaw(CameraOrientation orientation) {
+        getInstance()._yaw(orientation);
     }
     
-    static void roll(CameraRotation rotation) {
-        getInstance()._roll(rotation);
+    static void roll(CameraOrientation orientation) {
+        getInstance()._roll(orientation);
     }
     
     static void move(CameraMovement movement) {
         getInstance()._move(movement);
     }
     
-    static void pitchTo(float deg) {
-        getInstance()._pitchTo(deg);
-    }
-    
-    static void yawTo(float deg) {
-        getInstance()._yawTo(deg);
-    }
-    
-    static void rollTo(float deg) {
-        getInstance()._rollTo(deg);
-    }
-    
-    static void moveTo(float _x, float _y, float _z) {
-        getInstance()._moveTo(_x, _y, _z);
-    }
-    
     static void updateViewportSize(const int _gl_viewport_w, const int _gl_viewport_h) {
         getInstance()._updateViewportSize(_gl_viewport_w, _gl_viewport_h);
     }
     
-    static void reset(void) {
-        getInstance()._reset();
+    static void create(void) {
+        getInstance()._create();
     }
     
     static std::string repr(void) {

--- a/OpenGL/Camera.hpp
+++ b/OpenGL/Camera.hpp
@@ -15,9 +15,7 @@
 #include <iostream>
 #include <sstream>
 #include <string>
-#include "Matrices.hpp"
-
-#define one_deg_in_rad (2.0 * M_PI) / 360.0f
+#include "VecMat.hpp"
 
 enum CameraMovement {
     MOVE_FORWARD,
@@ -53,31 +51,32 @@ private:
     static Camera& getInstance();
     
     GLuint program;
-    Matrices m;
+    
+    mat4 T;
+    mat4 R;
+    mat4 view_mat;
+    mat4 proj_mat;
+    vec3 cam_pos;
+    
+    vec4 fwd;
+    vec4 rgt;
+    vec4 up;
+    
+    float quaternion[4];
     
     int gl_viewport_h;
     int gl_viewport_w;
-    float fov = 67.0f * one_deg_in_rad;
+    float fov = 67.0f;
     
-    float cam_pitch_speed = 0.4f;
-    float cam_yaw_speed = 0.4f;
-    float cam_roll_speed = 0.4f;
-    float cam_move_speed = 0.4f;
+    float cam_speed = 5.0f;
+    float cam_heading_speed = 100.0f;
     float cam_heading = 0.0f;
     
-    Matrix<float> fwd;
-    Matrix<float> rgt;
-    Matrix<float> up;
-    
-    Matrix<float> rotation_mat4;
-    Matrix<float> quaternion;
-    
-    Matrix<float> _calculateProjectionMatrix(void);
-    
+    void _create_versor(float *q, float a, float x, float y, float z);
+    void _quat_to_mat4(float *m, float *q);
     void _applyProgram(GLuint _progam);
     void _updateTranslation(void);
     void _updateViewportSize(const int _gl_viewport_w, const int gl_viewport_h);
-    void _applyProjection(const char *uniform_location_name);
     
     void _pitch(CameraOrientation orientation);
     void _yaw(CameraOrientation orientation);

--- a/OpenGL/Camera.hpp
+++ b/OpenGL/Camera.hpp
@@ -35,12 +35,6 @@ enum CameraOrientation {
     ROLL_RIGHT
 };
 
-enum RotationAxis {
-    AXIS_X,
-    AXIS_Y,
-    AXIS_Z
-};
-
 class Camera {
 
 private:
@@ -51,6 +45,8 @@ private:
     static Camera& getInstance();
     
     GLuint program;
+    int view_mat_location;
+    int proj_mat_location;
     
     mat4 T;
     mat4 R;
@@ -68,7 +64,7 @@ private:
     int gl_viewport_w;
     float fov = 67.0f;
     
-    float cam_speed = 5.0f;
+    float cam_speed = 0.25f;
     float cam_heading_speed = 100.0f;
     float cam_heading = 0.0f;
     
@@ -76,15 +72,16 @@ private:
     void _quat_to_mat4(float *m, float *q);
     void _applyProgram(GLuint _progam);
     void _updateTranslation(void);
-    void _updateViewportSize(const int _gl_viewport_w, const int gl_viewport_h);
     
     void _pitch(CameraOrientation orientation);
     void _yaw(CameraOrientation orientation);
     void _roll(CameraOrientation orientation);
-    void _move(CameraMovement movement);
+    void _moved(CameraMovement movement);
     
+    void _updateViewportSize(const int _gl_viewport_w, const int gl_viewport_h);
     void _create(void);
-    
+    void _move(vec3 movement);
+
     std::string _repr(void);
     
 public:
@@ -105,8 +102,8 @@ public:
         getInstance()._roll(orientation);
     }
     
-    static void move(CameraMovement movement) {
-        getInstance()._move(movement);
+    static void moved(CameraMovement movement) {
+        getInstance()._moved(movement);
     }
     
     static void updateViewportSize(const int _gl_viewport_w, const int _gl_viewport_h) {

--- a/OpenGL/Camera.hpp
+++ b/OpenGL/Camera.hpp
@@ -38,8 +38,7 @@ enum CameraRotation {
 enum RotationAxis {
     AXIS_X,
     AXIS_Y,
-    AXIS_Z,
-    AXIS_ALL
+    AXIS_Z
 };
 
 class Camera {
@@ -54,6 +53,10 @@ private:
     GLuint program;
     Matrices m;
     
+    int gl_viewport_h;
+    int gl_viewport_w;
+    float fov = 67.0f * one_deg_in_rad;
+    
     float cam_pos_x = 0.0f;
     float cam_pos_y = 0.0f;
     float cam_pos_z = 5.0f;
@@ -62,22 +65,25 @@ private:
     float cam_yaw = 0.0f;
     float cam_roll = 0.0f;
     
-    float cam_pitch_speed = 2.0f;
-    float cam_yaw_speed = 2.0f;
-    float cam_roll_speed = 2.0f;
+    float cam_pitch_speed = 0.1f;
+    float cam_yaw_speed = 0.1f;
+    float cam_roll_speed = 0.1f;
     float cam_move_speed = 0.1f;
+    float cam_heading = 0.0f;
     
     Matrix<float> fwd_mat4;
     Matrix<float> rgt_mat4;
     Matrix<float> up_mat4;
     Matrix<float> rotation_mat4;
     Matrix<float> quaternion_mat4;
-    
-    float fov = 67.0f * one_deg_in_rad;
+    Matrix<float> _calculateProjectionMatrix(void);
     
     void _applyProgram(GLuint _progam);
     void _updateTranslation(void);
-    void _applyViewQuaternionOnAxis(RotationAxis axis);
+    void _updateViewportSize(const int _gl_viewport_w, const int gl_viewport_h);
+    void _applyProjection(const char *uniform_location_name);
+    void _updateViewQuaternionOnAxis(RotationAxis axis);
+    void _applyView(void);
     
     void _pitch(CameraRotation rotation);
     void _yaw(CameraRotation rotation);
@@ -129,6 +135,10 @@ public:
     
     static void moveTo(float _x, float _y, float _z) {
         getInstance()._moveTo(_x, _y, _z);
+    }
+    
+    static void updateViewportSize(const int _gl_viewport_w, const int _gl_viewport_h) {
+        getInstance()._updateViewportSize(_gl_viewport_w, _gl_viewport_h);
     }
     
     static void reset(void) {

--- a/OpenGL/GLUtilities.cpp
+++ b/OpenGL/GLUtilities.cpp
@@ -109,8 +109,6 @@ GLint GLUtilities::programReady(const GLuint program) {
  *  Apply a projection matrix to a program
  */
 void GLUtilities::applyProjectionMatrix(const int gl_viewport_w, const int gl_viewport_h, const float fov, const GLuint program, const char *uniform_location_name) {
-    
-    
     /**
      *  We need to first calculate the projection matrix.
      *  We then unwind them from a Matrix to a vector of float values which
@@ -130,8 +128,6 @@ void GLUtilities::applyProjectionMatrix(const int gl_viewport_w, const int gl_vi
 }
 
 Matrix<GLfloat> GLUtilities::calculateProjectionMatrix(const int gl_viewport_w, const int gl_viewport_h, const float fov) {
-    
-    
     /**
      *  This sets up the Projection Matrix.
      *

--- a/OpenGL/Matrices.cpp
+++ b/OpenGL/Matrices.cpp
@@ -27,11 +27,11 @@ void Matrices::translate(AdjustmentType type, Adjustments adjustment) {
         case TRANSLATE_X: {
             switch(adjustment) {
                 case LEFT: {
-                    translate_x -= 0.025f;
+                    translate_x += 0.25f;
                     break;
                 }
                 case RIGHT: {
-                    translate_x += 0.025f;
+                    translate_x -= 0.25f;
                     break;
                 }
             }
@@ -40,11 +40,11 @@ void Matrices::translate(AdjustmentType type, Adjustments adjustment) {
         case TRANSLATE_Y: {
             switch(adjustment) {
                 case DOWN: {
-                    translate_y -= 0.025f;
+                    translate_y -= 0.25f;
                     break;
                 }
                 case UP: {
-                    translate_y += 0.025f;
+                    translate_y += 0.25f;
                     break;
                 }
             }
@@ -53,11 +53,11 @@ void Matrices::translate(AdjustmentType type, Adjustments adjustment) {
         case TRANSLATE_Z: {
             switch(adjustment) {
                 case CLOSER: {
-                    translate_z += 0.025f;
+                    translate_z += 0.25f;
                     break;
                 }
                 case FURTHER: {
-                    translate_z -= -0.025f;
+                    translate_z -= 0.25f;
                     break;
                 }
             }

--- a/OpenGL/Matrix.hpp
+++ b/OpenGL/Matrix.hpp
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <iostream>
 #include <cassert>
+#include "VecMat.hpp"
 
 /**
  *  Interface

--- a/OpenGL/Matrix.hpp
+++ b/OpenGL/Matrix.hpp
@@ -10,6 +10,8 @@
 #define Matrix_hpp
 
 #include <GLFW/glfw3.h>
+#include <string>
+#include <sstream>
 #include <vector>
 #include <algorithm>
 #include <iostream>
@@ -49,7 +51,10 @@ public:
     std::vector<T> unwind() const;
     void addRow(Row<T> row);
     void adjust(const int _row, const int _column, T value);
-    T getValue(int row, int index);
+    T getValueAtIndex(int index);
+    T getDeterminant(void);
+    Matrix<T> inverse(void);
+    std::string repr(void);
     
     bool operator==(const Matrix<T> &matrix) const;
     bool operator!=(const Matrix<T> &matrix) const;
@@ -107,8 +112,175 @@ void Matrix<T>::adjust(const int _row, const int _column, T value) {
 }
 
 template<typename T>
-T Matrix<T>::getValue(int row, int index) {
-    return rows.at(row).items.at(index);
+T Matrix<T>::getValueAtIndex(int index) {
+    std::vector<T>unwound = unwind();
+    return unwound.at(index);
+}
+
+template<typename T>
+T Matrix<T>::getDeterminant(void) {
+    return
+        getValueAtIndex(12) * getValueAtIndex(9) * getValueAtIndex(6) * getValueAtIndex(3) -
+        getValueAtIndex(8) * getValueAtIndex(13) * getValueAtIndex(6) * getValueAtIndex(3) -
+        getValueAtIndex(12) * getValueAtIndex(5) * getValueAtIndex(10) * getValueAtIndex(3) +
+        getValueAtIndex(4) * getValueAtIndex(13) * getValueAtIndex(10) * getValueAtIndex(3) +
+    
+        getValueAtIndex(8) * getValueAtIndex(5) * getValueAtIndex(14) * getValueAtIndex(3) -
+        getValueAtIndex(4) * getValueAtIndex(9) * getValueAtIndex(14) * getValueAtIndex(3) -
+        getValueAtIndex(12) * getValueAtIndex(9) * getValueAtIndex(2) * getValueAtIndex(7) +
+        getValueAtIndex(8) * getValueAtIndex(13) * getValueAtIndex(2) * getValueAtIndex(7) +
+    
+        getValueAtIndex(12) * getValueAtIndex(1) * getValueAtIndex(10) * getValueAtIndex(7) -
+        getValueAtIndex(0) * getValueAtIndex(13) * getValueAtIndex(10) * getValueAtIndex(7) -
+        getValueAtIndex(8) * getValueAtIndex(1) * getValueAtIndex(14) * getValueAtIndex(7) +
+        getValueAtIndex(0) * getValueAtIndex(9) * getValueAtIndex(14) * getValueAtIndex(7) +
+    
+        getValueAtIndex(12) * getValueAtIndex(5) * getValueAtIndex(2) * getValueAtIndex(11) -
+        getValueAtIndex(4) * getValueAtIndex(13) * getValueAtIndex(2) * getValueAtIndex(11) -
+        getValueAtIndex(12) * getValueAtIndex(1) * getValueAtIndex(6) * getValueAtIndex(11) +
+        getValueAtIndex(0) * getValueAtIndex(13) * getValueAtIndex(6) * getValueAtIndex(11) +
+    
+        getValueAtIndex(4) * getValueAtIndex(1) * getValueAtIndex(14) * getValueAtIndex(11) -
+        getValueAtIndex(0) * getValueAtIndex(5) * getValueAtIndex(14) * getValueAtIndex(11) -
+        getValueAtIndex(8) * getValueAtIndex(5) * getValueAtIndex(2) * getValueAtIndex(15) +
+        getValueAtIndex(4) * getValueAtIndex(9) * getValueAtIndex(2) * getValueAtIndex(15) +
+    
+        getValueAtIndex(8) * getValueAtIndex(1) * getValueAtIndex(6) * getValueAtIndex(15) -
+        getValueAtIndex(0) * getValueAtIndex(9) * getValueAtIndex(6) * getValueAtIndex(15) -
+        getValueAtIndex(4) * getValueAtIndex(1) * getValueAtIndex(10) * getValueAtIndex(15) +
+        getValueAtIndex(0) * getValueAtIndex(5) * getValueAtIndex(10) * getValueAtIndex(15);
+}
+
+template<typename T>
+Matrix<T> Matrix<T>::inverse(void) {
+    /**
+     *  Doing some checks to make sure the matrix is suitable.
+     *  It needs to be a 4x4 matrix.
+     */
+    assert(rows.size() == 4);
+    for(auto &row: rows) {
+        assert(row.items.size() == 4);
+    }
+    
+    Matrix<T> result;
+    float det = getDeterminant();
+    
+    if(0.0f == det) {
+        std::cout << "Warning: This matrix has no determinant so we cannot invert." << std::endl;
+        return *this;
+    }
+    
+    float inv_det = 1.0f / det;
+    
+    Row<T> row_1({
+        inv_det * (
+            getValueAtIndex(9) * getValueAtIndex(14) * getValueAtIndex(7) - getValueAtIndex(13) * getValueAtIndex(10) * getValueAtIndex(7) +
+            getValueAtIndex(13) * getValueAtIndex(6) * getValueAtIndex(11) - getValueAtIndex(5) * getValueAtIndex(14) * getValueAtIndex(11) -
+            getValueAtIndex(9) * getValueAtIndex(6) * getValueAtIndex(15) + getValueAtIndex(5) * getValueAtIndex(10) * getValueAtIndex(15)
+        ),
+        inv_det * (
+            getValueAtIndex(13) * getValueAtIndex(10) * getValueAtIndex(3) - getValueAtIndex(9) * getValueAtIndex(14) * getValueAtIndex(3) -
+            getValueAtIndex(13) * getValueAtIndex(2) * getValueAtIndex(11) + getValueAtIndex(1) * getValueAtIndex(14) * getValueAtIndex(11) +
+            getValueAtIndex(9) * getValueAtIndex(2) * getValueAtIndex(15) - getValueAtIndex(1) * getValueAtIndex(10) * getValueAtIndex(15)
+        ),
+        inv_det * (
+            getValueAtIndex(5) * getValueAtIndex(14) * getValueAtIndex(3) - getValueAtIndex(13) * getValueAtIndex(6) * getValueAtIndex(3) +
+            getValueAtIndex(13) * getValueAtIndex(2) * getValueAtIndex(7) - getValueAtIndex(1) * getValueAtIndex(14) * getValueAtIndex(7) -
+            getValueAtIndex(5) * getValueAtIndex(2) * getValueAtIndex(15) + getValueAtIndex(1) * getValueAtIndex(6) * getValueAtIndex(15)
+        ),
+        inv_det * (
+            getValueAtIndex(9) * getValueAtIndex(6) * getValueAtIndex(3) - getValueAtIndex(5) * getValueAtIndex(10) * getValueAtIndex(3) -
+            getValueAtIndex(9) * getValueAtIndex(2) * getValueAtIndex(7) + getValueAtIndex(1) * getValueAtIndex(10) * getValueAtIndex(7) +
+            getValueAtIndex(5) * getValueAtIndex(2) * getValueAtIndex(11) - getValueAtIndex(1) * getValueAtIndex(6) * getValueAtIndex(11)
+        )
+    });
+    
+    Row<T> row_2({
+        inv_det * (
+            getValueAtIndex(12) * getValueAtIndex(10) * getValueAtIndex(7) - getValueAtIndex(8) * getValueAtIndex(14) * getValueAtIndex(7) -
+            getValueAtIndex(12) * getValueAtIndex(6) * getValueAtIndex(11) + getValueAtIndex(4) * getValueAtIndex(14) * getValueAtIndex(11) +
+            getValueAtIndex(8) * getValueAtIndex(6) * getValueAtIndex(15) - getValueAtIndex(4) * getValueAtIndex(10) * getValueAtIndex(15)
+        ),
+        inv_det * (
+            getValueAtIndex(8) * getValueAtIndex(14) * getValueAtIndex(3) - getValueAtIndex(12) * getValueAtIndex(10) * getValueAtIndex(3) +
+            getValueAtIndex(12) * getValueAtIndex(2) * getValueAtIndex(11) - getValueAtIndex(0) * getValueAtIndex(14) * getValueAtIndex(11) -
+            getValueAtIndex(8) * getValueAtIndex(2) * getValueAtIndex(15) + getValueAtIndex(0) * getValueAtIndex(10) * getValueAtIndex(15)
+        ),
+        inv_det * (
+            getValueAtIndex(12) * getValueAtIndex(6) * getValueAtIndex(3) - getValueAtIndex(4) * getValueAtIndex(14) * getValueAtIndex(3) -
+            getValueAtIndex(12) * getValueAtIndex(2) * getValueAtIndex(7) + getValueAtIndex(0) * getValueAtIndex(14) * getValueAtIndex(7) +
+            getValueAtIndex(4) * getValueAtIndex(2) * getValueAtIndex(15) - getValueAtIndex(0) * getValueAtIndex(6) * getValueAtIndex(15)
+        ),
+        inv_det * (
+            getValueAtIndex(4) * getValueAtIndex(10) * getValueAtIndex(3) - getValueAtIndex(8) * getValueAtIndex(6) * getValueAtIndex(3) +
+            getValueAtIndex(8) * getValueAtIndex(2) * getValueAtIndex(7) - getValueAtIndex(0) * getValueAtIndex(10) * getValueAtIndex(7) -
+            getValueAtIndex(4) * getValueAtIndex(2) * getValueAtIndex(11) + getValueAtIndex(0) * getValueAtIndex(6) * getValueAtIndex(11)
+        )
+    });
+    
+    Row<T> row_3({
+        inv_det * (
+            getValueAtIndex(8) * getValueAtIndex(13) * getValueAtIndex(7) - getValueAtIndex(12) * getValueAtIndex(9) * getValueAtIndex(7) +
+            getValueAtIndex(12) * getValueAtIndex(5) * getValueAtIndex(11) - getValueAtIndex(4) * getValueAtIndex(13) * getValueAtIndex(11) -
+            getValueAtIndex(8) * getValueAtIndex(5) * getValueAtIndex(15) + getValueAtIndex(4) * getValueAtIndex(9) * getValueAtIndex(15)
+        ),
+        inv_det * (
+            getValueAtIndex(12) * getValueAtIndex(9) * getValueAtIndex(3) - getValueAtIndex(8) * getValueAtIndex(13) * getValueAtIndex(3) -
+            getValueAtIndex(12) * getValueAtIndex(1) * getValueAtIndex(11) + getValueAtIndex(0) * getValueAtIndex(13) * getValueAtIndex(11) +
+            getValueAtIndex(8) * getValueAtIndex(1) * getValueAtIndex(15) - getValueAtIndex(0) * getValueAtIndex(9) * getValueAtIndex(15)
+        ),
+        inv_det * (
+            getValueAtIndex(4) * getValueAtIndex(13) * getValueAtIndex(3) - getValueAtIndex(12) * getValueAtIndex(5) * getValueAtIndex(3) +
+            getValueAtIndex(12) * getValueAtIndex(1) * getValueAtIndex(7) - getValueAtIndex(0) * getValueAtIndex(13) * getValueAtIndex(7) -
+            getValueAtIndex(4) * getValueAtIndex(1) * getValueAtIndex(15) + getValueAtIndex(0) * getValueAtIndex(5) * getValueAtIndex(15)
+        ),
+        inv_det * (
+            getValueAtIndex(8) * getValueAtIndex(5) * getValueAtIndex(3) - getValueAtIndex(4) * getValueAtIndex(9) * getValueAtIndex(3) -
+            getValueAtIndex(8) * getValueAtIndex(1) * getValueAtIndex(7) + getValueAtIndex(0) * getValueAtIndex(9) * getValueAtIndex(7) +
+            getValueAtIndex(4) * getValueAtIndex(1) * getValueAtIndex(11) - getValueAtIndex(0) * getValueAtIndex(5) * getValueAtIndex(11)
+        )
+    });
+    
+    Row<T> row_4({
+        inv_det * (
+            getValueAtIndex(12) * getValueAtIndex(9) * getValueAtIndex(6) - getValueAtIndex(8) * getValueAtIndex(13) * getValueAtIndex(6) -
+            getValueAtIndex(12) * getValueAtIndex(5) * getValueAtIndex(10) + getValueAtIndex(4) * getValueAtIndex(13) * getValueAtIndex(10) +
+            getValueAtIndex(8) * getValueAtIndex(5) * getValueAtIndex(14) - getValueAtIndex(4) * getValueAtIndex(9) * getValueAtIndex(14)
+        ),
+        inv_det * (
+            getValueAtIndex(8) * getValueAtIndex(13) * getValueAtIndex(2) - getValueAtIndex(12) * getValueAtIndex(9) * getValueAtIndex(2) +
+            getValueAtIndex(12) * getValueAtIndex(1) * getValueAtIndex(10) - getValueAtIndex(0) * getValueAtIndex(13) * getValueAtIndex(10) -
+            getValueAtIndex(8) * getValueAtIndex(1) * getValueAtIndex(14) + getValueAtIndex(0) * getValueAtIndex(9) * getValueAtIndex(14)
+        ),
+        inv_det * (
+            getValueAtIndex(12) * getValueAtIndex(5) * getValueAtIndex(2) - getValueAtIndex(4) * getValueAtIndex(13) * getValueAtIndex(2) -
+            getValueAtIndex(12) * getValueAtIndex(1) * getValueAtIndex(6) + getValueAtIndex(0) * getValueAtIndex(13) * getValueAtIndex(6) +
+            getValueAtIndex(4) * getValueAtIndex(1) * getValueAtIndex(14) - getValueAtIndex(0) * getValueAtIndex(5) * getValueAtIndex(14)
+        ),
+        inv_det * (
+            getValueAtIndex(4) * getValueAtIndex(9) * getValueAtIndex(2) - getValueAtIndex(8) * getValueAtIndex(5) * getValueAtIndex(2) +
+            getValueAtIndex(8) * getValueAtIndex(1) * getValueAtIndex(6) - getValueAtIndex(0) * getValueAtIndex(9) * getValueAtIndex(6) -
+            getValueAtIndex(4) * getValueAtIndex(1) * getValueAtIndex(10) + getValueAtIndex(0) * getValueAtIndex(5) * getValueAtIndex(10)
+        )
+    });
+    
+    result.addRow(row_1);
+    result.addRow(row_2);
+    result.addRow(row_3);
+    result.addRow(row_4);
+    
+    return result;
+}
+
+template<typename T>
+std::string Matrix<T>::repr(void) {
+    std::stringstream oss;
+    for(auto &row : rows) {
+        for(auto &item : row.items) {
+            oss << item << ",";
+        }
+    }
+    return oss.str();
 }
 
 template<typename T>

--- a/OpenGL/Matrix.hpp
+++ b/OpenGL/Matrix.hpp
@@ -49,6 +49,7 @@ public:
     std::vector<T> unwind() const;
     void addRow(Row<T> row);
     void adjust(const int _row, const int _column, T value);
+    T getValue(int row, int index);
     
     bool operator==(const Matrix<T> &matrix) const;
     bool operator!=(const Matrix<T> &matrix) const;
@@ -103,6 +104,11 @@ void Matrix<T>::adjust(const int _row, const int _column, T value) {
     catch(std::exception &e) {
         std::cout << "Adjustment failed for row: " << _row << ", column: " << _column << std::endl;
     }
+}
+
+template<typename T>
+T Matrix<T>::getValue(int row, int index) {
+    return rows.at(row).items.at(index);
 }
 
 template<typename T>

--- a/OpenGL/Quaternion.cpp
+++ b/OpenGL/Quaternion.cpp
@@ -8,22 +8,61 @@
 
 #include "Quaternion.hpp"
 #include <cmath>
+#include <iostream>
+
+using namespace std;
 
 #define one_deg_in_rad (2.0 * M_PI) / 360.0f
 
+void Quaternion::normalise_quat(Matrix<float> &q) {
+    float q_0 = q.getValueAtIndex(0);
+    float q_1 = q.getValueAtIndex(1);
+    float q_2 = q.getValueAtIndex(2);
+    float q_3 = q.getValueAtIndex(3);
+    float sum = q_0 * q_0 + q_1 * q_1 + q_2 * q_2 + q_3 * q_3;
+    
+    const float thresh = 0.0001f;
+    if(fabs(1.0f - sum) < thresh) {
+        return;
+    }
+    
+    float mag = sqrt(sum);
+    for(int i = 0; i < 4; i++) {
+        int x = q.getValueAtIndex(i);
+        int val = x / mag;
+        q.adjust(0, i, val);
+    }
+    
+}
+
 void Quaternion::create_versor(Matrix<float> &m, float a, float x, float y, float z) {
+    
     float radians = one_deg_in_rad * a;
-    m.adjust(0, 0, cosf(radians / 2.0f));
-    m.adjust(0, 1, sinf(radians / 2.0f) * x);
-    m.adjust(0, 2, sinf(radians / 2.0f) * y);
-    m.adjust(0, 3, sinf(radians / 2.0f) * z);
+    
+    cout << "Create versor a: " << a <<  ", x: " << x << ", y: " << y << ", z: " << z << endl;
+    
+    if(m.getRows().size() != 0) {
+        m.adjust(0, 0, cosf(radians / 2.0f));
+        m.adjust(0, 0, cosf(radians / 2.0f) * x);
+        m.adjust(0, 0, cosf(radians / 2.0f) * y);
+        m.adjust(0, 0, cosf(radians / 2.0f) * z);
+    }
+    else {
+        Row<float> result({
+            cosf(radians / 2.0f),
+            sinf(radians / 2.0f) * x,
+            sinf(radians / 2.0f) * y,
+            sinf(radians / 2.0f) * z
+        });
+        m.addRow(result);
+    }
 }
 
 void Quaternion::quat_to_mat4(Matrix<float> &m, Matrix<float> q) {
-    float w = q.getValue(0, 0);
-    float x = q.getValue(0, 1);
-    float y = q.getValue(0, 2);
-    float z = q.getValue(0, 3);
+    float w = q.getValueAtIndex(0);
+    float x = q.getValueAtIndex(1);
+    float y = q.getValueAtIndex(2);
+    float z = q.getValueAtIndex(3);
     
     m.adjust(0, 0, (1.0f - 2.0f * y * y - 2.0f * z * z));
     m.adjust(0, 1, (2.0f * x * y + 2.0f * w * z));
@@ -46,40 +85,27 @@ void Quaternion::quat_to_mat4(Matrix<float> &m, Matrix<float> q) {
     m.adjust(3, 3, 1.0f);
 }
 
-void Quaternion::normalise_quat(Matrix<float> &q) {
-    float q_0 = q.getValue(0, 0);
-    float q_1 = q.getValue(0, 1);
-    float q_2 = q.getValue(0, 2);
-    float q_3 = q.getValue(0, 3);
-    float sum = q_0 * q_0 + q_1 * q_1 + q_2 * q_2 + q_3 * q_3;
-    
-    const float thresh = 0.0001f;
-    if(fabs(1.0f - sum) < thresh) {
-        return;
-    }
-    
-    float mag = sqrt(sum);
-    for(int i = 0; i < 4; i++) {
-        q.adjust(0, i, q.getValue(0, i) / mag);
-    }
-}
-
 void Quaternion::mult_quat_quat(Matrix<float> &result, Matrix<float> r, Matrix<float> s) {
     
-    float s_0 = s.getValue(0, 0);
-    float s_1 = s.getValue(0, 1);
-    float s_2 = s.getValue(0, 2);
-    float s_3 = s.getValue(0, 3);
+    float s_0 = s.getValueAtIndex(0);
+    float s_1 = s.getValueAtIndex(1);
+    float s_2 = s.getValueAtIndex(2);
+    float s_3 = s.getValueAtIndex(3);
     
-    float r_0 = r.getValue(0, 0);
-    float r_1 = r.getValue(0, 1);
-    float r_2 = r.getValue(0, 2);
-    float r_3 = r.getValue(0, 3);
+    float r_0 = r.getValueAtIndex(0);
+    float r_1 = r.getValueAtIndex(1);
+    float r_2 = r.getValueAtIndex(2);
+    float r_3 = r.getValueAtIndex(3);
+
+    float adj_1 = s_0 * r_0 - s_1 * r_1 - s_2 * r_2 - s_3 * r_3;
+    float adj_2 = s_0 * r_1 + s_1 * r_0 - s_2 * r_3 + s_3 * r_2;
+    float adj_3 = s_0 * r_2 + s_1 * r_3 + s_2 * r_0 - s_3 * r_1;
+    float adj_4 = s_0 * r_3 - s_1 * r_2 + s_2 * r_1 + s_3 * r_0;
     
-    result.adjust(0, 0, s_0 * r_0 - s_1 * r_1 - s_2 * r_2 - s_3 * r_3);
-    result.adjust(0, 1, s_0 * r_1 + s_1 * r_0 - s_2 * r_3 + s_3 * r_2);
-    result.adjust(0, 2, s_0 * r_2 + s_1 * r_3 + s_2 * r_0 - s_3 * r_1);
-    result.adjust(0, 3, s_0 * r_3 - s_1 * r_2 + s_2 * r_1 + s_3 * r_0);
+    result.adjust(0, 0, adj_1);
+    result.adjust(0, 1, adj_2);
+    result.adjust(0, 2, adj_3);
+    result.adjust(0, 3, adj_4);
     
     normalise_quat(result);
 }

--- a/OpenGL/Quaternion.cpp
+++ b/OpenGL/Quaternion.cpp
@@ -32,14 +32,11 @@ void Quaternion::normalise_quat(Matrix<float> &q) {
         int val = x / mag;
         q.adjust(0, i, val);
     }
-    
 }
 
 void Quaternion::create_versor(Matrix<float> &m, float a, float x, float y, float z) {
     
     float radians = one_deg_in_rad * a;
-    
-    cout << "Create versor a: " << a <<  ", x: " << x << ", y: " << y << ", z: " << z << endl;
     
     if(m.getRows().size() != 0) {
         m.adjust(0, 0, cosf(radians / 2.0f));
@@ -107,7 +104,7 @@ void Quaternion::mult_quat_quat(Matrix<float> &result, Matrix<float> r, Matrix<f
     result.adjust(0, 2, adj_3);
     result.adjust(0, 3, adj_4);
     
-    normalise_quat(result);
+//    normalise_quat(result);
 }
 
 

--- a/OpenGL/Quaternion.cpp
+++ b/OpenGL/Quaternion.cpp
@@ -11,58 +11,76 @@
 
 #define one_deg_in_rad (2.0 * M_PI) / 360.0f
 
-void Quaternion::create_versor(float *q, float a, float x, float y, float z) {
+void Quaternion::create_versor(Matrix<float> &m, float a, float x, float y, float z) {
     float radians = one_deg_in_rad * a;
-    q[0] = cosf(radians / 2.0f);
-    q[1] = sinf(radians / 2.0f) * x;
-    q[2] = sinf(radians / 2.0f) * y;
-    q[3] = sinf(radians / 2.0f) * z;
+    m.adjust(0, 0, cosf(radians / 2.0f));
+    m.adjust(0, 1, sinf(radians / 2.0f) * x);
+    m.adjust(0, 2, sinf(radians / 2.0f) * y);
+    m.adjust(0, 3, sinf(radians / 2.0f) * z);
 }
 
-void Quaternion::quat_to_mat4(Matrix<float> &m, float *quaternion) {
-    float w = quaternion[0];
-    float x = quaternion[1];
-    float y = quaternion[2];
-    float z = quaternion[3];
+void Quaternion::quat_to_mat4(Matrix<float> &m, Matrix<float> q) {
+    float w = q.getValue(0, 0);
+    float x = q.getValue(0, 1);
+    float y = q.getValue(0, 2);
+    float z = q.getValue(0, 3);
     
     m.adjust(0, 0, (1.0f - 2.0f * y * y - 2.0f * z * z));
     m.adjust(0, 1, (2.0f * x * y + 2.0f * w * z));
     m.adjust(0, 2, (2.0f * x * z - 2.0f * w * y));
     m.adjust(0, 3, 0.0f);
-    
+
     m.adjust(1, 0, (2.0f * x * y - 2.0f * w * z));
     m.adjust(1, 1, (1.0f - 2.0f * x * x -2.0f * z * z));
     m.adjust(1, 2, (2.0f * y * z + 2.0f * w * x));
     m.adjust(1, 3, 0.0f);
-    
+
     m.adjust(2, 0, (2.0f * x * z + 2.0f * w * y));
     m.adjust(2, 1, (2.0f * y * z - 2.0f * w * x));
     m.adjust(2, 2, (1.0f - 2.0f * x * x - 2.0f * y * y));
     m.adjust(2, 3, 0.0f);
-    
+
     m.adjust(3, 0, 0.0f);
     m.adjust(3, 1, 0.0f);
     m.adjust(3, 2, 0.0f);
     m.adjust(3, 3, 1.0f);
 }
 
-void Quaternion::normalise_quat(float *q) {
-    float sum = q[0] * q[0] + q[1] * q[1] + q[2] * q[2] + q[3] * q[3];
+void Quaternion::normalise_quat(Matrix<float> &q) {
+    float q_0 = q.getValue(0, 0);
+    float q_1 = q.getValue(0, 1);
+    float q_2 = q.getValue(0, 2);
+    float q_3 = q.getValue(0, 3);
+    float sum = q_0 * q_0 + q_1 * q_1 + q_2 * q_2 + q_3 * q_3;
+    
     const float thresh = 0.0001f;
     if(fabs(1.0f - sum) < thresh) {
         return;
     }
+    
     float mag = sqrt(sum);
     for(int i = 0; i < 4; i++) {
-        q[i] = q[i] / mag;
+        q.adjust(0, i, q.getValue(0, i) / mag);
     }
 }
 
-void Quaternion::mult_quat_quat(float *result, float *r, float *s) {
-    result[0] = s[0] * r[0] - s[1] * r[1] - s[2] * r[2] - s[3] * r[3];
-    result[1] = s[0] * r[1] + s[1] * r[0] - s[2] * r[3] + s[3] * r[2];
-    result[2] = s[0] * r[2] + s[1] * r[3] + s[2] * r[0] - s[3] * r[1];
-    result[3] = s[0] * r[3] - s[1] * r[2] + s[2] * r[1] + s[3] * r[0];
+void Quaternion::mult_quat_quat(Matrix<float> &result, Matrix<float> r, Matrix<float> s) {
+    
+    float s_0 = s.getValue(0, 0);
+    float s_1 = s.getValue(0, 1);
+    float s_2 = s.getValue(0, 2);
+    float s_3 = s.getValue(0, 3);
+    
+    float r_0 = r.getValue(0, 0);
+    float r_1 = r.getValue(0, 1);
+    float r_2 = r.getValue(0, 2);
+    float r_3 = r.getValue(0, 3);
+    
+    result.adjust(0, 0, s_0 * r_0 - s_1 * r_1 - s_2 * r_2 - s_3 * r_3);
+    result.adjust(0, 1, s_0 * r_1 + s_1 * r_0 - s_2 * r_3 + s_3 * r_2);
+    result.adjust(0, 2, s_0 * r_2 + s_1 * r_3 + s_2 * r_0 - s_3 * r_1);
+    result.adjust(0, 3, s_0 * r_3 - s_1 * r_2 + s_2 * r_1 + s_3 * r_0);
+    
     normalise_quat(result);
 }
 

--- a/OpenGL/Quaternion.hpp
+++ b/OpenGL/Quaternion.hpp
@@ -12,10 +12,12 @@
 #include "Matrix.hpp"
 
 class Quaternion {
+private:
+    static void normalise_quat(Matrix<float> &q);
+    
 public:
     static void create_versor(Matrix<float> &m, float a, float x, float y, float z);
     static void quat_to_mat4(Matrix<float> &m, Matrix<float> q);
-    static void normalise_quat(Matrix<float> &q);
     static void mult_quat_quat(Matrix<float> &result, Matrix<float> r, Matrix<float> s);
 };
 

--- a/OpenGL/Quaternion.hpp
+++ b/OpenGL/Quaternion.hpp
@@ -13,10 +13,10 @@
 
 class Quaternion {
 public:
-    static void create_versor(float *q, float a, float x, float y, float z);
-    static void quat_to_mat4(Matrix<float> &m, float *quaternion);
-    static void normalise_quat(float *q);
-    static void mult_quat_quat(float * result, float *r, float *s);
+    static void create_versor(Matrix<float> &m, float a, float x, float y, float z);
+    static void quat_to_mat4(Matrix<float> &m, Matrix<float> q);
+    static void normalise_quat(Matrix<float> &q);
+    static void mult_quat_quat(Matrix<float> &result, Matrix<float> r, Matrix<float> s);
 };
 
 #endif /* Quaternion_hpp */

--- a/OpenGL/QuaternionDemo.cpp
+++ b/OpenGL/QuaternionDemo.cpp
@@ -164,10 +164,11 @@ int QuaternionDemo::start() {
          *      Quaternion view matrix to the world.
          */
         Camera::applyProgram(program);
+        Camera::updateViewportSize(gl_viewport_w, gl_viewport_h);
         Camera::reset();
         cout << Camera::repr() << endl;
         
-        GLUtilities::applyProjectionMatrix(gl_viewport_w, gl_viewport_h, fov, program, "projection");
+//        GLUtilities::applyProjectionMatrix(gl_viewport_w, gl_viewport_h, fov, program, "projection");
     }
     
     while(!glfwWindowShouldClose(window)) {

--- a/OpenGL/QuaternionDemo.cpp
+++ b/OpenGL/QuaternionDemo.cpp
@@ -77,43 +77,51 @@ void QuaternionDemo::keyActionListener(void) {
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_A)) {
-        Camera::moved(MOVE_LEFT);
+        Camera::update(MOVE_LEFT);
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_D)) {
-        Camera::moved(MOVE_RIGHT);
+        Camera::update(MOVE_RIGHT);
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_W)) {
-        Camera::moved(MOVE_FORWARD);
+        Camera::update(MOVE_FORWARD);
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_S)) {
-        Camera::moved(MOVE_BACKWARD);
+        Camera::update(MOVE_BACKWARD);
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_Q)) {
-        Camera::moved(MOVE_UP);
+        Camera::update(MOVE_UP);
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_E)) {
-        Camera::moved(MOVE_DOWN);
+        Camera::update(MOVE_DOWN);
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_UP)) {
-//        Camera::move(MOVE_FORWARD);
+        Camera::update(PITCH_UP);
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_DOWN)) {
-//        Camera::move(MOVE_BACKWARD);
+        Camera::update(PITCH_DOWN);
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_LEFT)) {
-//        Camera::move(MOVE_LEFT);
+        Camera::update(YAW_LEFT);
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_RIGHT)) {
-//        Camera::move(MOVE_RIGHT);
+        Camera::update(YAW_RIGHT);
+    }
+    
+    if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_Z)) {
+        Camera::update(ROLL_LEFT);
+    }
+    
+    if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_C)) {
+        Camera::update(ROLL_RIGHT);
     }
 }
 

--- a/OpenGL/QuaternionDemo.cpp
+++ b/OpenGL/QuaternionDemo.cpp
@@ -77,43 +77,43 @@ void QuaternionDemo::keyActionListener(void) {
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_A)) {
-        Camera::yaw(YAW_LEFT);
+        Camera::moved(MOVE_LEFT);
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_D)) {
-        Camera::yaw(YAW_RIGHT);
+        Camera::moved(MOVE_RIGHT);
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_W)) {
-        Camera::pitch(PITCH_UP);
+        Camera::moved(MOVE_FORWARD);
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_S)) {
-        Camera::pitch(PITCH_DOWN);
+        Camera::moved(MOVE_BACKWARD);
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_Q)) {
-        Camera::roll(ROLL_LEFT);
+        Camera::moved(MOVE_UP);
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_E)) {
-        Camera::roll(ROLL_RIGHT);
+        Camera::moved(MOVE_DOWN);
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_UP)) {
-        Camera::move(MOVE_FORWARD);
+//        Camera::move(MOVE_FORWARD);
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_DOWN)) {
-        Camera::move(MOVE_BACKWARD);
+//        Camera::move(MOVE_BACKWARD);
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_LEFT)) {
-        Camera::move(MOVE_LEFT);
+//        Camera::move(MOVE_LEFT);
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_RIGHT)) {
-        Camera::move(MOVE_RIGHT);
+//        Camera::move(MOVE_RIGHT);
     }
 }
 

--- a/OpenGL/QuaternionDemo.cpp
+++ b/OpenGL/QuaternionDemo.cpp
@@ -70,7 +70,6 @@ void QuaternionDemo::keyActionListener(void) {
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_ENTER)) {
-        Camera::reset();
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_ESCAPE)) {
@@ -78,27 +77,27 @@ void QuaternionDemo::keyActionListener(void) {
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_A)) {
-        Camera::yaw(ROT_LEFT);
+        Camera::yaw(YAW_LEFT);
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_D)) {
-        Camera::yaw(ROT_RIGHT);
+        Camera::yaw(YAW_RIGHT);
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_W)) {
-        Camera::pitch(ROT_UP);
+        Camera::pitch(PITCH_UP);
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_S)) {
-        Camera::pitch(ROT_DOWN);
+        Camera::pitch(PITCH_DOWN);
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_Q)) {
-        Camera::roll(ROT_LEFT);
+        Camera::roll(ROLL_LEFT);
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_E)) {
-        Camera::roll(ROT_RIGHT);
+        Camera::roll(ROLL_RIGHT);
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_UP)) {
@@ -165,10 +164,8 @@ int QuaternionDemo::start() {
          */
         Camera::applyProgram(program);
         Camera::updateViewportSize(gl_viewport_w, gl_viewport_h);
-        Camera::reset();
-        cout << Camera::repr() << endl;
-        
-//        GLUtilities::applyProjectionMatrix(gl_viewport_w, gl_viewport_h, fov, program, "projection");
+        Camera::create();
+        cout << Camera::repr() << endl;        
     }
     
     while(!glfwWindowShouldClose(window)) {

--- a/OpenGL/QuaternionDemo.cpp
+++ b/OpenGL/QuaternionDemo.cpp
@@ -16,7 +16,7 @@
 #include "Camera.hpp"
 
 #define gl_viewport_w 1280
-#define gl_viewport_h 960
+#define gl_viewport_h 720
 
 using namespace std;
 
@@ -69,9 +69,6 @@ void QuaternionDemo::keyActionListener(void) {
         return;
     }
     
-    if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_ENTER)) {
-    }
-    
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_ESCAPE)) {
         glfwSetWindowShouldClose(window, 1);
     }
@@ -122,6 +119,16 @@ void QuaternionDemo::keyActionListener(void) {
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_C)) {
         Camera::update(ROLL_RIGHT);
+    }
+    
+    if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_MINUS)) {
+        Camera::updateFov(-0.5f);
+        glfwSetWindowTitle(window, Camera::repr().c_str());
+    }
+    
+    if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_EQUAL)) {
+        Camera::updateFov(0.5f);
+        glfwSetWindowTitle(window, Camera::repr().c_str());
     }
 }
 

--- a/OpenGL/QuaternionDemo.cpp
+++ b/OpenGL/QuaternionDemo.cpp
@@ -69,14 +69,8 @@ void QuaternionDemo::keyActionListener(void) {
         return;
     }
     
-    if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_1)) {
-        Camera::switcRotationType(QUATERNION);
-        glfwSetWindowTitle(window, "Rotating using Quaternions");
-    }
-    
-    if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_2)) {
-        Camera::switcRotationType(EULER);
-        glfwSetWindowTitle(window, "Rotating using Eulers");
+    if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_ENTER)) {
+        Camera::reset();
     }
     
     if(GLFW_PRESS == glfwGetKey(window, GLFW_KEY_ESCAPE)) {
@@ -170,7 +164,7 @@ int QuaternionDemo::start() {
          *      Quaternion view matrix to the world.
          */
         Camera::applyProgram(program);
-        Camera::moveTo(0.0f, 0.0f, 15.0f);
+        Camera::reset();
         cout << Camera::repr() << endl;
         
         GLUtilities::applyProjectionMatrix(gl_viewport_w, gl_viewport_h, fov, program, "projection");

--- a/OpenGL/QuaternionDemo.hpp
+++ b/OpenGL/QuaternionDemo.hpp
@@ -29,9 +29,7 @@ private:
     GLuint program;
     GLFWwindow *window;
     GLenum drawing_method = GL_TRIANGLES;
-    
-    float fov = 67.0f * one_deg_in_rad;
-    
+        
     std::vector<Mesh> meshes;
     
     void createProgram(void);

--- a/OpenGL/VecMat.cpp
+++ b/OpenGL/VecMat.cpp
@@ -10,8 +10,6 @@
 #include <iostream>
 #include <cmath>
 
-#define one_deg_in_rad (2.0 * M_PI) / 360.0f
-
 vec2::vec2() {}
 
 vec2::vec2(float x, float y) {
@@ -45,6 +43,64 @@ mat3 zero_mat3() {
         0.0f, 0.0f, 0.0f,
         0.0f, 0.0f, 0.0f
     );
+}
+
+mat3 identity_mat3() {
+    return mat3(
+        1.0f, 0.0f, 0.0f,
+        0.0f, 1.0f, 0.0f,
+        0.0f, 0.0f, 1.0f
+    );
+}
+
+float length2(const vec3 &v) {
+    return v.v[0] * v.v[0] +  v.v[1] * v.v[1] +  v.v[2] * v.v[2];
+}
+
+float length(const vec3 &v) {
+    return sqrt(length2(v));
+}
+
+float dot(const vec3 &a, const vec3 &b) {
+    return
+        a.v[0] * b.v[0] +
+        a.v[1] * b.v[1] +
+        a.v[2] * b.v[2];
+}
+
+vec3 cross(const vec3 &a, const vec3 &b) {
+    float x = a.v[1] * b.v[2] - a.v[2] * b.v[1];
+    float y = a.v[2] * b.v[0] - a.v[0] * b.v[2];
+    float z = a.v[0] * b.v[1] - a.v[1] * b.v[0];
+    return vec3(x, y, z);
+}
+
+float get_squared_dist(vec3 from, vec3 to) {
+    float x = (to.v[0] - from.v[0]) * (to.v[0] - from.v[0]);
+    float y = (to.v[1] - from.v[1]) * (to.v[1] - from.v[1]);
+    float z = (to.v[2] - from.v[2]) * (to.v[2] - from.v[2]);
+    return x + y + z;
+}
+
+float direction_to_heading(vec3 d) {
+    return atan2(-d.v[0], -d.v[2]) * one_deg_in_rad;
+}
+
+vec3 normalise(const vec3 &v) {
+    vec3 v_n;
+    float l = length(v);
+    if(0.0f == l) {
+        return vec3(0.0f, 0.0f, 0.0f);
+    }
+    v_n.v[0] = v.v[0] / l;
+    v_n.v[1] = v.v[1] / l;
+    v_n.v[2] = v.v[2] / l;
+    return v_n;
+}
+
+vec3 heading_to_direction(float degrees) {
+    float rad = degrees * one_deg_in_rad;
+    return vec3(-sinf(rad), 0.0f, -cosf(rad));
 }
 
 vec4::vec4() {}
@@ -406,5 +462,14 @@ mat4 inverse(const mat4 &mm) {
             mm.m[8] * mm.m[1] * mm.m[6] - mm.m[0] * mm.m[9] * mm.m[6] -
             mm.m[4] * mm.m[1] * mm.m[10] + mm.m[0] * mm.m[5] * mm.m[10]
         )
+    );
+}
+
+mat4 transpose(const mat4 &mm) {
+    return mat4(
+        mm.m[0], mm.m[4], mm.m[8], mm.m[12],
+        mm.m[1], mm.m[5], mm.m[9], mm.m[13],
+        mm.m[2], mm.m[6], mm.m[10], mm.m[14],
+        mm.m[3], mm.m[7], mm.m[11], mm.m[15]
     );
 }

--- a/OpenGL/VecMat.cpp
+++ b/OpenGL/VecMat.cpp
@@ -7,6 +7,10 @@
 //
 
 #include "VecMat.hpp"
+#include <iostream>
+#include <cmath>
+
+#define one_deg_in_rad (2.0 * M_PI) / 360.0f
 
 vec2::vec2() {}
 
@@ -33,6 +37,14 @@ vec3::vec3(const vec4 &vv) {
     v[0] = vv.v[0];
     v[1] = vv.v[1];
     v[2] = vv.v[2];
+}
+
+mat3 zero_mat3() {
+    return mat3(
+        0.0f, 0.0f, 0.0f,
+        0.0f, 0.0f, 0.0f,
+        0.0f, 0.0f, 0.0f
+    );
 }
 
 vec4::vec4() {}
@@ -133,4 +145,266 @@ vec3 vec3::operator=(const vec3 &rhs) {
     result.v[1] = rhs.v[1];
     result.v[2] = rhs.v[2];
     return result;
+}
+
+mat3::mat3() {}
+
+mat3::mat3(
+    float a, float b, float c,
+    float d, float e, float f,
+    float g, float h, float i) {
+    m[0] = a;
+    m[1] = b;
+    m[2] = c;
+    m[3] = d;
+    m[4] = e;
+    m[5] = f;
+    m[6] = g;
+    m[7] = h;
+    m[8] = i;
+}
+
+mat4::mat4() {}
+
+mat4::mat4(
+    float a, float b, float c, float d,
+    float e, float f, float g, float h,
+    float i, float j, float k, float l,
+    float mm, float n, float o, float p) {
+    m[0] = a;
+    m[1] = b;
+    m[2] = c;
+    m[3] = d;
+    m[4] = e;
+    m[5] = f;
+    m[6] = g;
+    m[7] = h;
+    m[8] = i;
+    m[9] = j;
+    m[10] = k;
+    m[11] = l;
+    m[12] = mm;
+    m[13] = n;
+    m[14] = o;
+    m[14] = p;
+}
+
+mat4 zero_mat4() {
+    return mat4(
+        0.0f, 0.0f, 0.0f, 0.0f,
+        0.0f, 0.0f, 0.0f, 0.0f,
+        0.0f, 0.0f, 0.0f, 0.0f,
+        0.0f, 0.0f, 0.0f, 0.0f
+    );
+}
+
+mat4 identity_mat4() {
+    return mat4(
+        1.0f, 0.0f, 0.0f, 0.0f,
+        1.0f, 1.0f, 0.0f, 0.0f,
+        1.0f, 0.0f, 1.0f, 0.0f,
+        1.0f, 0.0f, 0.0f, 1.0f
+    );
+}
+
+vec4 mat4::operator*(const vec4 &rhs) {
+    float x =
+        m[0] * rhs.v[0] +
+        m[4] * rhs.v[1] +
+        m[8] * rhs.v[2] +
+        m[12] * rhs.v[3];
+    
+    float y =
+        m[1] * rhs.v[0] +
+        m[5] * rhs.v[1] +
+        m[9] * rhs.v[2] +
+        m[13] * rhs.v[3];
+    
+    float z =
+        m[2] * rhs.v[0] +
+        m[6] * rhs.v[1] +
+        m[10] * rhs.v[2] +
+        m[14] * rhs.v[3];
+
+    float w =
+        m[3] * rhs.v[0] +
+        m[7] * rhs.v[1] +
+        m[11] * rhs.v[2] +
+        m[15] * rhs.v[3];
+    
+    return vec4(x, y, z, w);
+}
+
+mat4 mat4::operator*(const mat4 &rhs) {
+    mat4 result = zero_mat4();
+    
+    int r_index = 0;
+    for(int col = 0; col < 4; col++) {
+        for(int r = 0; r < 4; r++) {
+            float sum = 0.0f;
+            for(int i = 0; i < 4; i++) {
+                sum += rhs.m[i + col * 4] * m[r + i * 4];
+            }
+            result.m[r_index] = sum;
+            r_index++;
+        }
+    }
+    return result;
+}
+
+mat4& mat4::operator=(const mat4 &rhs) {
+    for(int i = 0; i < 16; i++) {
+        m[i] = rhs.m[i];
+    }
+    return *this;
+}
+
+mat4 translate(const mat4 &m, const vec3 &v) {
+    mat4 m_t = identity_mat4();
+    m_t.m[12] = v.v[0];
+    m_t.m[13] = v.v[1];
+    m_t.m[14] = v.v[2];
+    return m_t * m;
+}
+
+mat4 perspective(float fovy, float aspect, float near, float far) {
+    float fov_rads = fovy * one_deg_in_rad;
+    float range = tan(fov_rads / 2.0f) * near;
+    float sx = (2.0f * near) / (range * aspect + range * aspect);
+    float sy = near / range;
+    float sz = -(far + near) / (far - near);
+    float pz = -(2.0f * far * near) / (far - near);
+    mat4 m = zero_mat4();
+    m.m[0] = sx;
+    m.m[5] = sy;
+    m.m[10] = sz;
+    m.m[14] = pz;
+    m.m[11] = -1.0f;
+    return m;
+}
+
+float determinant(const mat4 &mm) {
+    return
+        mm.m[12] * mm.m[9] * mm.m[6] * mm.m[3] -
+        mm.m[8] * mm.m[13] * mm.m[6] * mm.m[3] -
+        mm.m[12] * mm.m[5] * mm.m[10] * mm.m[3] +
+        mm.m[4] * mm.m[13] * mm.m[10] * mm.m[3] +
+        
+        mm.m[8] * mm.m[5] * mm.m[14] * mm.m[3] -
+        mm.m[4] * mm.m[9] * mm.m[14] * mm.m[3] -
+        mm.m[12] * mm.m[9] * mm.m[2] * mm.m[7] +
+        mm.m[8] * mm.m[13] * mm.m[2] * mm.m[7] +
+        
+        mm.m[12] * mm.m[1] * mm.m[10] * mm.m[7] -
+        mm.m[0] * mm.m[13] * mm.m[10] * mm.m[7] -
+        mm.m[8] * mm.m[1] * mm.m[14] * mm.m[7] +
+        mm.m[0] * mm.m[9] * mm.m[14] * mm.m[7] +
+        
+        mm.m[12] * mm.m[5] * mm.m[2] * mm.m[11] -
+        mm.m[4] * mm.m[13] * mm.m[2] * mm.m[11] -
+        mm.m[12] * mm.m[1] * mm.m[6] * mm.m[11] +
+        mm.m[0] * mm.m[13] * mm.m[6] * mm.m[11] +
+        
+        mm.m[4] * mm.m[1] * mm.m[14] * mm.m[11] -
+        mm.m[0] * mm.m[5] * mm.m[14] * mm.m[11] -
+        mm.m[8] * mm.m[5] * mm.m[2] * mm.m[15] +
+        mm.m[4] * mm.m[9] * mm.m[2] * mm.m[15] +
+        
+        mm.m[8] * mm.m[1] * mm.m[6] * mm.m[15] -
+        mm.m[0] * mm.m[9] * mm.m[6] * mm.m[15] -
+        mm.m[4] * mm.m[1] * mm.m[10] * mm.m[15] +
+        mm.m[0] * mm.m[5] * mm.m[10] * mm.m[15];
+}
+
+mat4 inverse(const mat4 &mm) {
+    float det = determinant(mm);
+    if(0.0f == det) {
+        std::cout << "Unable to get the determinant for this mat4." << std::endl;
+        return mm;
+    }
+    
+    float inv_det = 1.0f / det;
+    
+    return mat4(
+        inv_det * (
+            mm.m[9] * mm.m[14] * mm.m[7] - mm.m[13] * mm.m[10] * mm.m[7] +
+            mm.m[13] * mm.m[6] * mm.m[11] - mm.m[5] * mm.m[14] * mm.m[11] -
+            mm.m[9] * mm.m[6] * mm.m[15] + mm.m[5] * mm.m[10] * mm.m[15]
+        ),
+        inv_det * (
+            mm.m[13] * mm.m[10] * mm.m[3] - mm.m[9] * mm.m[14] * mm.m[3] -
+            mm.m[13] * mm.m[2] * mm.m[11] + mm.m[1] * mm.m[14] * mm.m[11] +
+            mm.m[9] * mm.m[2] * mm.m[15] - mm.m[1] * mm.m[10] * mm.m[15]
+        ),
+        inv_det * (
+            mm.m[5] * mm.m[14] * mm.m[3] - mm.m[13] * mm.m[6] * mm.m[3] +
+            mm.m[13] * mm.m[2] * mm.m[7] - mm.m[1] * mm.m[14] * mm.m[7] -
+            mm.m[5] * mm.m[2] * mm.m[15] + mm.m[1] * mm.m[6] * mm.m[15]
+        ),
+        inv_det * (
+            mm.m[9] * mm.m[6] * mm.m[3] - mm.m[5] * mm.m[10] * mm.m[3] -
+            mm.m[9] * mm.m[2] * mm.m[7] + mm.m[1] * mm.m[10] * mm.m[7] +
+            mm.m[5] * mm.m[2] * mm.m[11] - mm.m[1] * mm.m[6] * mm.m[11]
+        ),
+        inv_det * (
+            mm.m[12] * mm.m[10] * mm.m[7] - mm.m[8] * mm.m[14] * mm.m[7] -
+            mm.m[12] * mm.m[6] * mm.m[11] + mm.m[4] * mm.m[14] * mm.m[11] +
+            mm.m[8] * mm.m[6] * mm.m[15] - mm.m[4] * mm.m[10] * mm.m[15]
+                   ),
+        inv_det * (
+            mm.m[8] * mm.m[14] * mm.m[3] - mm.m[12] * mm.m[10] * mm.m[3] +
+            mm.m[12] * mm.m[2] * mm.m[11] - mm.m[0] * mm.m[14] * mm.m[11] -
+            mm.m[8] * mm.m[2] * mm.m[15] + mm.m[0] * mm.m[10] * mm.m[15]
+        ),
+        inv_det * (
+            mm.m[12] * mm.m[6] * mm.m[3] - mm.m[4] * mm.m[14] * mm.m[3] -
+            mm.m[12] * mm.m[2] * mm.m[7] + mm.m[0] * mm.m[14] * mm.m[7] +
+            mm.m[4] * mm.m[2] * mm.m[15] - mm.m[0] * mm.m[6] * mm.m[15]
+        ),
+        inv_det * (
+            mm.m[4] * mm.m[10] * mm.m[3] - mm.m[8] * mm.m[6] * mm.m[3] +
+            mm.m[8] * mm.m[2] * mm.m[7] - mm.m[0] * mm.m[10] * mm.m[7] -
+            mm.m[4] * mm.m[2] * mm.m[11] + mm.m[0] * mm.m[6] * mm.m[11]
+        ),
+        inv_det * (
+            mm.m[8] * mm.m[13] * mm.m[7] - mm.m[12] * mm.m[9] * mm.m[7] +
+            mm.m[12] * mm.m[5] * mm.m[11] - mm.m[4] * mm.m[13] * mm.m[11] -
+            mm.m[8] * mm.m[5] * mm.m[15] + mm.m[4] * mm.m[9] * mm.m[15]
+        ),
+        inv_det * (
+            mm.m[12] * mm.m[9] * mm.m[3] - mm.m[8] * mm.m[13] * mm.m[3] -
+            mm.m[12] * mm.m[1] * mm.m[11] + mm.m[0] * mm.m[13] * mm.m[11] +
+            mm.m[8] * mm.m[1] * mm.m[15] - mm.m[0] * mm.m[9] * mm.m[15]
+        ),
+        inv_det * (
+            mm.m[4] * mm.m[13] * mm.m[3] - mm.m[12] * mm.m[5] * mm.m[3] +
+            mm.m[12] * mm.m[1] * mm.m[7] - mm.m[0] * mm.m[13] * mm.m[7] -
+            mm.m[4] * mm.m[1] * mm.m[15] + mm.m[0] * mm.m[5] * mm.m[15]
+        ),
+        inv_det * (
+            mm.m[8] * mm.m[5] * mm.m[3] - mm.m[4] * mm.m[9] * mm.m[3] -
+            mm.m[8] * mm.m[1] * mm.m[7] + mm.m[0] * mm.m[9] * mm.m[7] +
+            mm.m[4] * mm.m[1] * mm.m[11] - mm.m[0] * mm.m[5] * mm.m[11]
+        ),
+        inv_det * (
+            mm.m[12] * mm.m[9] * mm.m[6] - mm.m[8] * mm.m[13] * mm.m[6] -
+            mm.m[12] * mm.m[5] * mm.m[10] + mm.m[4] * mm.m[13] * mm.m[10] +
+            mm.m[8] * mm.m[5] * mm.m[14] - mm.m[4] * mm.m[9] * mm.m[14]
+        ),
+        inv_det * (
+            mm.m[8] * mm.m[13] * mm.m[2] - mm.m[12] * mm.m[9] * mm.m[2] +
+            mm.m[12] * mm.m[1] * mm.m[10] - mm.m[0] * mm.m[13] * mm.m[10] -
+            mm.m[8] * mm.m[1] * mm.m[14] + mm.m[0] * mm.m[9] * mm.m[14]
+        ),
+        inv_det * (
+            mm.m[12] * mm.m[5] * mm.m[2] - mm.m[4] * mm.m[13] * mm.m[2] -
+            mm.m[12] * mm.m[1] * mm.m[6] + mm.m[0] * mm.m[13] * mm.m[6] +
+            mm.m[4] * mm.m[1] * mm.m[14] - mm.m[0] * mm.m[5] * mm.m[14]
+        ),
+        inv_det * (
+            mm.m[4] * mm.m[9] * mm.m[2] - mm.m[8] * mm.m[5] * mm.m[2] +
+            mm.m[8] * mm.m[1] * mm.m[6] - mm.m[0] * mm.m[9] * mm.m[6] -
+            mm.m[4] * mm.m[1] * mm.m[10] + mm.m[0] * mm.m[5] * mm.m[10]
+        )
+    );
 }

--- a/OpenGL/VecMat.cpp
+++ b/OpenGL/VecMat.cpp
@@ -1,0 +1,136 @@
+//
+//  VecMat.cpp
+//  OpenGL
+//
+//  Created by Matt Finucane on 01/03/2017.
+//  Copyright © 2017 Matt Finucane. All rights reserved.
+//
+
+#include "VecMat.hpp"
+
+vec2::vec2() {}
+
+vec2::vec2(float x, float y) {
+    v[0] = x;
+    v[1] = y;
+}
+
+vec3::vec3() {}
+
+vec3::vec3(float x, float y, float z) {
+    v[0] = x;
+    v[1] = y;
+    v[2] = z;
+}
+
+vec3::vec3(const vec2 &vv, float z) {
+    v[0] = vv.v[0];
+    v[1] = vv.v[1];
+    v[2] = z;
+}
+
+vec3::vec3(const vec4 &vv) {
+    v[0] = vv.v[0];
+    v[1] = vv.v[1];
+    v[2] = vv.v[2];
+}
+
+vec4::vec4() {}
+
+vec4::vec4(float x, float y, float z, float w) {
+    v[0] = x;
+    v[1] = y;
+    v[2] = z;
+    v[3] = w;
+}
+
+vec4::vec4(const vec2 &vv, float z, float w) {
+    v[0] = vv.v[0];
+    v[1] = vv.v[1];
+    v[2] = z;
+    v[3] = w;
+}
+
+vec4::vec4(const vec3 &vv, float w) {
+    v[0] = vv.v[0];
+    v[1] = vv.v[1];
+    v[2] = vv.v[2];
+    v[3] = w;
+}
+
+vec3 vec3::operator+(const vec3 &rhs) {
+    vec3 result;
+    result.v[0] = v[0] + rhs.v[0];
+    result.v[1] = v[1] + rhs.v[1];
+    result.v[2] = v[2] + rhs.v[2];
+    return result;
+}
+
+vec3 vec3::operator+(float rhs) {
+    vec3 result;
+    result.v[0] = v[0] + rhs;
+    result.v[1] = v[1] + rhs;
+    result.v[2] = v[2] + rhs;
+    return result;
+}
+
+vec3& vec3::operator+=(const vec3 &rhs) {
+    v[0] += rhs.v[0];
+    v[1] += rhs.v[1];
+    v[2] += rhs.v[2];
+    return *this;
+}
+
+vec3 vec3::operator-(const vec3 &rhs) {
+    vec3 result;
+    result.v[0] = v[0] = rhs.v[0];
+    result.v[1] = v[1] = rhs.v[1];
+    result.v[2] = v[2] = rhs.v[2];
+    return result;
+}
+
+vec3 vec3::operator-(float rhs) {
+    vec3 result;
+    result.v[0] = v[0] - rhs;
+    result.v[1] = v[1] - rhs;
+    result.v[2] = v[2] - rhs;
+    return result;
+}
+
+vec3& vec3::operator-=(const vec3 &rhs) {
+    v[0] -= rhs.v[0];
+    v[1] -= rhs.v[1];
+    v[2] -= rhs.v[2];
+    return *this;
+}
+
+vec3 vec3::operator*(float rhs) {
+    vec3 result;
+    result.v[0] = v[0] * rhs;
+    result.v[1] = v[1] * rhs;
+    result.v[2] = v[2] * rhs;
+    return result;
+}
+
+vec3& vec3::operator*=(const vec3 &rhs) {
+    v[0] *= rhs.v[0];
+    v[1] *= rhs.v[1];
+    v[2] *= rhs.v[2];
+    return *this;
+}
+
+vec3 vec3::operator/(float rhs) {
+    vec3 result;
+    result.v[0] = v[0] / rhs;
+    result.v[1] = v[1] / rhs;
+    result.v[2] = v[2] / rhs;
+    return result;
+}
+
+vec3 vec3::operator=(const vec3 &rhs) {
+    vec3 result;
+    result.v[0] = rhs.v[0];
+    result.v[1] = rhs.v[1];
+    result.v[2] = rhs.v[2];
+    return result;
+}

--- a/OpenGL/VecMat.cpp
+++ b/OpenGL/VecMat.cpp
@@ -195,12 +195,11 @@ vec3 vec3::operator/(float rhs) {
     return result;
 }
 
-vec3 vec3::operator=(const vec3 &rhs) {
-    vec3 result;
-    result.v[0] = rhs.v[0];
-    result.v[1] = rhs.v[1];
-    result.v[2] = rhs.v[2];
-    return result;
+vec3& vec3::operator=(const vec3 &rhs) {
+    v[0] = rhs.v[0];
+    v[1] = rhs.v[1];
+    v[2] = rhs.v[2];
+    return *this;
 }
 
 mat3::mat3() {}
@@ -242,7 +241,7 @@ mat4::mat4(
     m[12] = mm;
     m[13] = n;
     m[14] = o;
-    m[14] = p;
+    m[15] = p;
 }
 
 mat4 zero_mat4() {
@@ -257,9 +256,9 @@ mat4 zero_mat4() {
 mat4 identity_mat4() {
     return mat4(
         1.0f, 0.0f, 0.0f, 0.0f,
-        1.0f, 1.0f, 0.0f, 0.0f,
-        1.0f, 0.0f, 1.0f, 0.0f,
-        1.0f, 0.0f, 0.0f, 1.0f
+        0.0f, 1.0f, 0.0f, 0.0f,
+        0.0f, 0.0f, 1.0f, 0.0f,
+        0.0f, 0.0f, 0.0f, 1.0f
     );
 }
 
@@ -378,13 +377,13 @@ mat4 translate(const mat4 &m, const vec3 &v) {
 }
 
 mat4 perspective(float fovy, float aspect, float near, float far) {
-    float fov_rads = fovy * one_deg_in_rad;
-    float range = tan(fov_rads / 2.0f) * near;
+    float fov_rad = fovy * one_deg_in_rad;
+    float range = tan (fov_rad / 2.0f) * near;
     float sx = (2.0f * near) / (range * aspect + range * aspect);
     float sy = near / range;
     float sz = -(far + near) / (far - near);
     float pz = -(2.0f * far * near) / (far - near);
-    mat4 m = zero_mat4();
+    mat4 m = zero_mat4 (); // make sure bottom-right corner is zero
     m.m[0] = sx;
     m.m[5] = sy;
     m.m[10] = sz;

--- a/OpenGL/VecMat.cpp
+++ b/OpenGL/VecMat.cpp
@@ -315,6 +315,55 @@ mat4& mat4::operator=(const mat4 &rhs) {
     return *this;
 }
 
+versor::versor() {}
+
+versor versor::operator/(float rhs) {
+    versor result;
+    result.q[0] = q[0] / rhs;
+    result.q[1] = q[1] / rhs;
+    result.q[2] = q[2] / rhs;
+    result.q[3] = q[3] / rhs;
+    return result;
+}
+
+versor versor::operator*(float rhs) {
+    versor result;
+    result.q[0] = q[0] * rhs;
+    result.q[1] = q[1] * rhs;
+    result.q[2] = q[2] * rhs;
+    result.q[3] = q[3] * rhs;
+    return result;
+}
+
+versor versor::operator*(const versor &rhs) {
+    versor result;
+    result.q[0] = rhs.q[0] * q[0] - rhs.q[1] * q[1] - rhs.q[2] * q[2] - rhs.q[3] * q[3];
+    
+    result.q[1] = rhs.q[0] * q[1] + rhs.q[1] * q[0] - rhs.q[2] * q[3] + rhs.q[3] * q[2];
+    
+    result.q[2] = rhs.q[0] * q[2] + rhs.q[1] * q[3] + rhs.q[2] * q[0] - rhs.q[3] * q[1];
+    
+    result.q[3] = rhs.q[0] * q[3] - rhs.q[1] * q[2] + rhs.q[2] * q[1] + rhs.q[3] * q[0];
+    
+    return normalise(result);
+}
+
+versor versor::operator+(const versor &rhs) {
+    return versor();
+}
+
+versor normalise(versor &q) {
+    float sum =
+        q.q[0] * q.q[0] + q.q[1] * q.q[1] +
+        q.q[2] * q.q[2] + q.q[3] * q.q[3];
+    const float thresh = 0.0001f;
+    if(fabs(1.0f) - sum < thresh) {
+        return q;
+    }
+    float mag = sqrt(sum);
+    return q / mag;
+}
+
 mat4 translate(const mat4 &m, const vec3 &v) {
     mat4 m_t = identity_mat4();
     m_t.m[12] = v.v[0];
@@ -472,4 +521,70 @@ mat4 transpose(const mat4 &mm) {
         mm.m[2], mm.m[6], mm.m[10], mm.m[14],
         mm.m[3], mm.m[7], mm.m[11], mm.m[15]
     );
+}
+
+mat4 rotate_x_deg(const mat4 &m, float deg) {
+    float rad = deg * one_deg_in_rad;
+    mat4 m_r = identity_mat4();
+    m_r.m[5] = cosf(rad);
+    m_r.m[9] = -sinf(rad);
+    m_r.m[6] = sinf(rad);
+    m_r.m[10] = cosf(rad);
+    return m_r * m;
+}
+
+mat4 rotate_y_deg(const mat4 &m, float deg) {
+    float rad = deg * one_deg_in_rad;
+    mat4 m_r = identity_mat4();
+    m_r.m[0] = cosf(rad);
+    m_r.m[8] = sinf(rad);
+    m_r.m[2] = -sinf(rad);
+    m_r.m[10] = cosf(rad);
+    return m_r * m;
+}
+
+mat4 rotate_z_deg(const mat4 &m, float deg) {
+    float rad = deg * one_deg_in_rad;
+    mat4 m_r = identity_mat4();
+    m_r.m[0] = cosf(rad);
+    m_r.m[4] = -sinf(rad);
+    m_r.m[1] = sinf(rad);
+    m_r.m[5] = cosf(rad);
+    return m_r * m;
+}
+
+mat4 scale(const mat4 &m, vec3 &v) {
+    mat4 a = identity_mat4();
+    a.m[0] = v.v[0];
+    a.m[5] = v.v[1];
+    a.m[10] = v.v[2];
+    return a * m;
+}
+
+mat4 look_at(const vec3 &cam_pos, vec3 target_pos, const vec3 &up) {
+    mat4 p = identity_mat4();
+    
+    p = translate(p, vec3(-cam_pos.v[0], -cam_pos.v[1], -cam_pos.v[2]));
+    vec3 d = target_pos - cam_pos;
+    vec3 f = normalise(d);
+    vec3 r = normalise(cross(f, up));
+    vec3 u = normalise(cross(r, f));
+    
+    mat4 ori = identity_mat4();
+    
+    ori.m[0] = r.v[0];
+    ori.m[4] = r.v[1];
+    ori.m[8] = r.v[2];
+    ori.m[1] = r.v[0];
+    ori.m[5] = u.v[1];
+    ori.m[9] = u.v[2];
+    ori.m[2] = -f.v[0];
+    ori.m[6] = -f.v[1];
+    ori.m[10] = -f.v[2];
+    
+    return ori * p;
+}
+
+versor quat_from_axis_rad(float radians, float x, float y, float z) {
+    return versor();
 }

--- a/OpenGL/VecMat.hpp
+++ b/OpenGL/VecMat.hpp
@@ -112,9 +112,24 @@ mat4 zero_mat4();
 mat4 identity_mat4();
 mat4 translate(const mat4 &m, const vec3 &v);
 mat4 perspective(float fovy, float aspect, float near, float far);
+mat4 look_at(const vec3 &cam_pos, vec3 target_pos, const vec3 &up);
 float determinant(const mat4 &mm);
 mat4 inverse(const mat4 &mm);
 mat4 transpose(const mat4 &mm);
+mat4 rotate_x_deg(const mat4 &m, float deg);
+mat4 rotate_y_deg(const mat4 &m, float deg);
+mat4 rotate_z_deg(const mat4 &m, float deg);
+mat4 scale(const mat4 &m, const vec3 &v);
 
+/**
+ *  Functions versors - helpful for Quaternions
+ */
+versor quat_from_axis_rad(float radians, float x, float y, float z);
+versor quat_from_axis_deg(float degress, float x, float y, float z);
+mat4 quat_to_mat4(const versor &q);
+float dot(const versor &q, const versor &r);
+versor slerp(const versor &q, const versor &r);
+versor normalise(versor &q);
+versor slerp(versor &q, versor &r, float t);
 
 #endif /* VecMat_hpp */

--- a/OpenGL/VecMat.hpp
+++ b/OpenGL/VecMat.hpp
@@ -128,8 +128,7 @@ versor quat_from_axis_rad(float radians, float x, float y, float z);
 versor quat_from_axis_deg(float degress, float x, float y, float z);
 mat4 quat_to_mat4(const versor &q);
 float dot(const versor &q, const versor &r);
-versor slerp(const versor &q, const versor &r);
-versor normalise(versor &q);
 versor slerp(versor &q, versor &r, float t);
+versor normalise(versor &q);
 
 #endif /* VecMat_hpp */

--- a/OpenGL/VecMat.hpp
+++ b/OpenGL/VecMat.hpp
@@ -68,7 +68,7 @@ struct mat4 {
         float a, float b, float c, float d,
         float e, float f, float g, float h,
         float i, float j, float k, float l,
-        float m, float n, float o, float p
+        float mm, float n, float o, float p
     );
     
     vec4 operator*(const vec4 &rhs);

--- a/OpenGL/VecMat.hpp
+++ b/OpenGL/VecMat.hpp
@@ -1,0 +1,81 @@
+//
+//  VecMat.hpp
+//  OpenGL
+//
+//  Created by Matt Finucane on 01/03/2017.
+//  Copyright © 2017 Matt Finucane. All rights reserved.
+//
+
+#ifndef VecMat_hpp
+#define VecMat_hpp
+
+struct vec2;
+struct vec3;
+struct vec4;
+struct mat3;
+struct mat4;
+
+struct vec2 {
+    vec2();
+    vec2(float x, float y);
+    
+    float v[2];
+};
+
+struct vec3 {
+    vec3();
+    vec3(float x, float y, float z);
+    vec3(const vec2 &vv, float z);
+    vec3(const vec4 &vv);
+    
+    vec3 operator+(const vec3 &rhs);
+    vec3 operator+(float rhs);
+    vec3& operator+=(const vec3 &rhs);
+    vec3 operator-(const vec3 &rhs);
+    vec3 operator-(float rhs);
+    vec3& operator-=(const vec3 &rhs);
+    vec3 operator*(float rhs);
+    vec3& operator*=(const vec3 &rhs);
+    vec3 operator/(float rhs);
+    vec3 operator=(const vec3 &rhs);
+    
+    float v[3];
+};
+
+struct vec4 {
+    vec4();
+    vec4(float x, float y, float z, float w);
+    vec4(const vec2 &vv, float z, float w);
+    vec4(const vec3 &vv, float w);
+    
+    float v[4];
+};
+
+struct mat3 {
+    mat3();
+    mat3(
+        float a, float b, float c,
+        float d, float e, float f,
+        float g, float h, float i
+    );
+    
+    float m[9];
+};
+
+struct mat4 {
+    mat4();
+    mat4(
+        float a, float b, float c, float d,
+        float e, float f, float g, float h,
+        float i, float j, float k, float l,
+        float m, float n, float o, float p
+    );
+    
+    vec4 operator*(const vec4 &rhs);
+    mat4 operator*(const mat4 &rhs);
+    mat4& operator=(const mat4 &rhs);
+    
+    float m[16];
+};
+
+#endif /* VecMat_hpp */

--- a/OpenGL/VecMat.hpp
+++ b/OpenGL/VecMat.hpp
@@ -9,11 +9,15 @@
 #ifndef VecMat_hpp
 #define VecMat_hpp
 
+#define one_deg_in_rad (2.0 * M_PI) / 360.0f
+#define one_rad_in_deg 360.0f / (2.0 * M_PI)
+
 struct vec2;
 struct vec3;
 struct vec4;
 struct mat3;
 struct mat4;
+struct versor;
 
 struct vec2 {
     vec2();
@@ -77,5 +81,40 @@ struct mat4 {
     
     float m[16];
 };
+
+struct versor {
+    versor();
+    versor operator/(float rhs);
+    versor operator*(float rhs);
+    versor operator*(const versor &rhs);
+    versor operator+(const versor &rhs);
+    float q[4];
+};
+
+/**
+ *  Functions for vectors
+ */
+float length(const vec3 &v);
+float length2(const vec3 &v);
+float dot(const vec3 &a, const vec3 &b);
+float get_squared_dist(vec3 from, vec3 to);
+float direction_to_heading(vec3 d);
+vec3 cross(const vec3 &a, const vec3 &b);
+vec3 normalise(const vec3 &v);
+vec3 heading_to_direction(float degrees);
+
+/**
+ *  Functions for matrices
+ */
+mat3 zero_mat3();
+mat3 identity_mat3();
+mat4 zero_mat4();
+mat4 identity_mat4();
+mat4 translate(const mat4 &m, const vec3 &v);
+mat4 perspective(float fovy, float aspect, float near, float far);
+float determinant(const mat4 &mm);
+mat4 inverse(const mat4 &mm);
+mat4 transpose(const mat4 &mm);
+
 
 #endif /* VecMat_hpp */

--- a/OpenGL/VecMat.hpp
+++ b/OpenGL/VecMat.hpp
@@ -9,7 +9,7 @@
 #ifndef VecMat_hpp
 #define VecMat_hpp
 
-#define one_deg_in_rad (2.0 * M_PI) / 360.0f
+#define one_deg_in_rad (2.0 * M_PI) / 360.0
 #define one_rad_in_deg 360.0f / (2.0 * M_PI)
 
 struct vec2;
@@ -41,7 +41,7 @@ struct vec3 {
     vec3 operator*(float rhs);
     vec3& operator*=(const vec3 &rhs);
     vec3 operator/(float rhs);
-    vec3 operator=(const vec3 &rhs);
+    vec3& operator=(const vec3 &rhs);
     
     float v[3];
 };

--- a/OpenGL/main.cpp
+++ b/OpenGL/main.cpp
@@ -252,6 +252,4 @@ int main(int argc, const char * argv[]) {
 //    int mo_run = distanceCalculatorDemo();
 //    int run = runCameraPerspectiveDemo();
     int run = runQuaternionDemo();
-    
-    return 0;
 }


### PR DESCRIPTION
This PR fixes issues with the older Quaternion functionality for moving and rotating the camera. It replaces the use of my own `Matrix` and `Matrices` functions with the `VecMat` functions to handle operations on vectors and matrices.

The camera can now move and rotate around in a somewhat first person mode.